### PR TITLE
Python3 compatibility for cmp in agromanager

### DIFF
--- a/pcse/agromanager.py
+++ b/pcse/agromanager.py
@@ -25,6 +25,14 @@ from .util import ConfigurationLoader
 from . import signals
 from . import exceptions as exc
 
+def cmp2(x, y):
+    """
+    Compare two values and return sign
+
+    Surrogate for cmp() function in Python2
+    """
+    return (x > y) - (x < y)
+
 def check_date_range(day, start, end):
     """returns True if start <= day < end
 
@@ -460,7 +468,7 @@ class StateEventsDispatcher(HasTraits, DispatcherObject):
 
 
     def _zero_condition_falling(self, current_state, state, keywords, zero_condition_sign):
-        sign = (current_state - state > 0) - (current_state - state < 0)
+        sign = cmp2(current_state - state, 0)
 
         # is None: e.g. called the first time and zero_condition_sign is not yet calculated
         if zero_condition_sign is None:
@@ -474,7 +482,7 @@ class StateEventsDispatcher(HasTraits, DispatcherObject):
         return sign
 
     def _zero_condition_rising(self, current_state, state, kwargs, zero_condition_sign):
-        sign = (current_state - state > 0) - (current_state - state < 0)
+        sign = cmp2(current_state - state, 0)
 
         # is None: e.g. called the first time and zero_condition_sign is not yet calculated
         if zero_condition_sign is None:
@@ -488,7 +496,7 @@ class StateEventsDispatcher(HasTraits, DispatcherObject):
         return sign
 
     def _zero_condition_either(self, current_state, state, keywords, zero_condition_sign):
-        sign = (current_state - state > 0) - (current_state - state < 0)
+        sign = cmp2(current_state - state, 0)
 
         # is None: e.g. called the first time and zero_condition_sign is not yet calculated
         if zero_condition_sign is None:

--- a/pcse/agromanager.py
+++ b/pcse/agromanager.py
@@ -460,7 +460,7 @@ class StateEventsDispatcher(HasTraits, DispatcherObject):
 
 
     def _zero_condition_falling(self, current_state, state, keywords, zero_condition_sign):
-        sign = cmp(current_state - state, 0)
+        sign = (current_state - state > 0) - (current_state - state < 0)
 
         # is None: e.g. called the first time and zero_condition_sign is not yet calculated
         if zero_condition_sign is None:
@@ -474,7 +474,7 @@ class StateEventsDispatcher(HasTraits, DispatcherObject):
         return sign
 
     def _zero_condition_rising(self, current_state, state, kwargs, zero_condition_sign):
-        sign = cmp(current_state - state, 0)
+        sign = (current_state - state > 0) - (current_state - state < 0)
 
         # is None: e.g. called the first time and zero_condition_sign is not yet calculated
         if zero_condition_sign is None:
@@ -488,7 +488,7 @@ class StateEventsDispatcher(HasTraits, DispatcherObject):
         return sign
 
     def _zero_condition_either(self, current_state, state, keywords, zero_condition_sign):
-        sign = cmp(current_state - state, 0)
+        sign = (current_state - state > 0) - (current_state - state < 0)
 
         # is None: e.g. called the first time and zero_condition_sign is not yet calculated
         if zero_condition_sign is None:


### PR DESCRIPTION
First idea was to change cmp() to (current_state - state > 0) - (current_state - state < 0). What do you think?