### PR TITLE
avoid division by zero error in growth reduction function

### DIFF
--- a/pcse/crop/lintul3.py
+++ b/pcse/crop/lintul3.py
@@ -20,6 +20,8 @@ cm2mm = lambda x: x*10.
 joule2megajoule = lambda x: x/1e6
 m2mm = lambda x: x*1000
 
+EPSILON = 10e-10
+
 class Lintul3(SimulationObject):
     """
         * ORIGINAL COPYRGIGHT NOTICE:    
@@ -518,7 +520,7 @@ class Lintul3(SimulationObject):
         SLA = p.SLAC * p.SLACF(DVS) * exp(-p.NSLA * (1.-NNI))
 
         # Growth reduction function for water stress(actual trans/potential)
-        r.TRANRF = r.TRAN / r.PTRAN
+        r.TRANRF = r.TRAN / (r.PTRAN + EPSILON)
 
         # relative modification for root and shoot allocation.
         FRT, FLV, FST, FSO = self.dryMatterPartitioningFractions(p.NPART, r.TRANRF, NNI, FRTWET, FLVT, FSTT, FSOT)

--- a/pcse/crop/lintul3.py
+++ b/pcse/crop/lintul3.py
@@ -20,8 +20,6 @@ cm2mm = lambda x: x*10.
 joule2megajoule = lambda x: x/1e6
 m2mm = lambda x: x*1000
 
-EPSILON = 10e-10
-
 class Lintul3(SimulationObject):
     """
         * ORIGINAL COPYRGIGHT NOTICE:    
@@ -520,7 +518,7 @@ class Lintul3(SimulationObject):
         SLA = p.SLAC * p.SLACF(DVS) * exp(-p.NSLA * (1.-NNI))
 
         # Growth reduction function for water stress(actual trans/potential)
-        r.TRANRF = r.TRAN / (r.PTRAN + EPSILON)
+        r.TRANRF = r.TRAN / r.PTRAN if (r.PTRAN != 0) else 1
 
         # relative modification for root and shoot allocation.
         FRT, FLV, FST, FSO = self.dryMatterPartitioningFractions(p.NPART, r.TRANRF, NNI, FRTWET, FLVT, FSTT, FSOT)


### PR DESCRIPTION
When r.PTRAN = 0 the current formula results in division by zero.