### PR TITLE
Undefine name delts --> delt

### DIFF
--- a/doc/downloads/example_simobj.py
+++ b/doc/downloads/example_simobj.py
@@ -52,7 +52,7 @@ class CropProcess(SimulationObject):
         """
         
         self.states.STATE1 += self.rates.RATE1 * delt
-        self.states.STATE2 += self.rates.RATE2 * delts
+        self.states.STATE2 += self.rates.RATE2 * delt
 
         msg = "State update finished on CropProcess on %s." % day
         self.logger.info(msg)


### PR DESCRIPTION
Also, `cmp()` and `file` were removed in Python 3.

$ `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
```
./pcse/doc/downloads/example_simobj.py:55:50: F821 undefined name 'delts'
        self.states.STATE2 += self.rates.RATE2 * delts
                                                 ^
./pcse/pcse/fileinput/cabo_weather.py:340:35: F821 undefined name 'file'
            raise PCSEError(msg % file)
                                  ^
./pcse/pcse/pydispatch/saferef.py:154:11: F821 undefined name 'cmp'
			return cmp( self.__class__, type(other) )
			       ^
./pcse/pcse/pydispatch/saferef.py:155:10: F821 undefined name 'cmp'
		return cmp( self.key, other.key)
		       ^
4     F821 undefined name 'delts'
4
```