### PR TITLE
update get_user_home() for MacOS

### DIFF
--- a/pcse/util.py
+++ b/pcse/util.py
@@ -1096,7 +1096,8 @@ def get_user_home():
         user = os.getenv("USERNAME")
         if user is not None:
             user_home = os.path.expanduser("~")
-    elif platform.system() == "Linux":
+    # For Linux of Mac
+    elif platform.system() == "Linux" or platform.system() == 'Darwin':
         user = os.getenv("USER")
         if user is not None:
             user_home = os.path.expanduser("~")


### PR DESCRIPTION
Quick update for using PCSE on Macs.

Behavior prior to change:

```
>>> import pcse
Platform not recognized, using system temp directory for PCSE settings.
Platform not recognized, using system temp directory for PCSE settings.
Building PCSE demo database at: /var/folders/gp/<random folder name>/T/.pcse/pcse.db ... OK
```

Behavior after change:

```
>>> import pcse
Building PCSE demo database at: /Users/<username>/.pcse/pcse.db ... OK
```

And, for reference:

```
>>> import platform
>>> platform.system()
'Darwin'
```

Running on macOS Ventura 13.4.1, Python 3.10.12