### PR TITLE
Minor textual fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,11 +19,11 @@ inherent limitations of models written in FORTRAN is also becoming increasingly 
 To overcome many of the limitations above, the Python Crop Simulation Environment
 (PCSE) was developed which provides an environment for developing simulation models
 as well as a number of implementations of crop simulation models. PCSE is written
-in pure python code which makes it more flexible, easier to modify and extensible
+in pure Python code which makes it more flexible, easier to modify and extensible
 allowing easy interfacing with databases, graphical user interfaces, visualization
 tools and numerical/statistical packages. PCSE has several interesting features:
 
-* Implementation in pure python with dependencies only on popular packages available from
+* Implementation in pure Python with dependencies only on popular packages available from
   the Python Package Index (PyPI) (`SQLAlchemy`, `PyYAML`, `pandas`, `Openpyxl`, `xlrd`,
   `requests` and `numpy`)
 

--- a/README.rst
+++ b/README.rst
@@ -125,7 +125,7 @@ data which can be used to compare the results from a PCSE model against. Experim
 'experimental collection' which contains references to experiments that belong together. For example, all
 experiments for potato for a given variety. Currently, the available experiments are limited to grassland for the
 LINGRA model and consist of two collections. One for grassland under irrigated conditions and one for rain-fed
-conditions. Tt is expected that more experimental data will be collected and stored here in order to have a
+conditions. It is expected that more experimental data will be collected and stored here in order to have a
 reference set to compare model results.
 
 Running the experiments is similar to running the unit tests::

--- a/doc/available_models.rst
+++ b/doc/available_models.rst
@@ -20,6 +20,6 @@ LINTUL3                An implementation of the LINTUL3 model for production sce
 FAO_WRSI               An implementation of the Water Requirement Satisfaction Index model. This re-uses components
                        from WOFOST to create a simpler approach which computes water requirements and water availability.
 Wofost72_Phenology     The phenology modules from WOFOST 7.2 as a standalone model. This is purely for convenience as in
-                       some cases running the phenology is sufficient and this is much faster then running the full
+                       some cases running the phenology is sufficient and this is much faster than running the full
                        WOFOST model.
 ===================== =======================================================================================================

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -4,10 +4,10 @@ Installing PCSE
 Requirements and dependencies
 -----------------------------
 
-PCSE is being developed on Ubuntu Linux 18.04 and Windows 10 using python 3.7 and python 3.8
+PCSE is being developed on Ubuntu Linux 18.04 and Windows 10 using Python 3.7 and Python 3.8
 As Python is a platform independent language, PCSE works equally well on Linux, Windows or Mac OSX.
 Before installing PCSE, Python itself must be installed on your system which we will demonstrate
-below. PCSE has a number of dependencies on other python packages which are the following::
+below. PCSE has a number of dependencies on other Python packages which are the following::
 
 - SQLAlchemy>=0.8.0
 - PyYAML>=3.11
@@ -27,16 +27,16 @@ additional functionality used by PCSE.
 .. _HomeBrew: http://brew.sh
 .. _traitlets: https://traitlets.readthedocs.io/en/stable/
 
-Setting up your python environment
+Setting up your Python environment
 ----------------------------------
 
-A convenient way to set up your python environment for PCSE is through the `Anaconda`_ python distribution.
+A convenient way to set up your Python environment for PCSE is through the `Anaconda`_ Python distribution.
 In the present PCSE Documentation all examples of installing and using PCSE refer to the Windows 10 platform.
 
-First, we suggest you download and install the `MiniConda`_ python distribution which provides a minimum
-python environment that we will use to bootstrap a dedicated environment for PCSE. For the rest
+First, we suggest you download and install the `MiniConda`_ Python distribution which provides a minimum
+Python environment that we will use to bootstrap a dedicated environment for PCSE. For the rest
 of this guide we will assume that you use Windows 10 and install the
-64bit miniconda for python 3 (``Miniconda3-latest-Windows-x86_64.exe``). The environment that
+64bit miniconda for Python 3 (``Miniconda3-latest-Windows-x86_64.exe``). The environment that
 we will create contains not only the dependencies for PCSE, it also includes many other useful packages
 such as `IPython`_, `Pandas`_ and the `Jupyter notebook`_. These packages will be used in the Getting Started section
 as well.
@@ -83,14 +83,14 @@ After installing MiniConda you should open a command box and check that conda is
                      netrc file : None
                    offline mode : False
 
-Now we will use a Conda environment file to recreate the python environment that we use to develop and run
+Now we will use a Conda environment file to recreate the Python environment that we use to develop and run
 PCSE. First you should download the conda environment file which comes in two flavours, an
-environment for running PCSE on python 3 (:download:`downloads/py3_pcse.yml`) and one for python 2
-(:download:`downloads/py2_pcse.yml`). It is strongly recommended to use the python 3 version as python 2
+environment for running PCSE on Python 3 (:download:`downloads/py3_pcse.yml`) and one for Python 2
+(:download:`downloads/py2_pcse.yml`). It is strongly recommended to use the Python 3 version as Python 2
 is not maintained anymore. Both environments include the Jupyter notebook and IPython which are
 needed for running the `getting started` section and the example notebooks. Save the environment file
 on a temporary location such as ``d:\temp\make_env\``. We will now create a dedicated virtual environment
-using the command ``conda env create`` and tell conda to use the environment file for python3 with the
+using the command ``conda env create`` and tell conda to use the environment file for Python 3 with the
 option ``-f p3_pcse.yml`` as show below:
 
 .. code-block:: doscon
@@ -127,11 +127,11 @@ You can then activate your environment (note the addition of ``(py3_pcse)`` on y
 Installing PCSE
 ---------------
 
-The easiest way to install PCSE is through the python package index (`PyPI`_).
+The easiest way to install PCSE is through the Python package index (`PyPI`_).
 Installing from PyPI is mostly useful if you are interested in using the functionality
 provided by PCSE in your own scripts, but are not interested in modifying or contributing to
 PCSE itself. Installing from PyPI is done using the package installer `pip` which searches
-the python package index for a package, downloads and installs it into your python
+the Python package index for a package, downloads and installs it into your Python
 environment (example below for PCSE 5.4):
 
 .. code-block:: doscon
@@ -168,11 +168,11 @@ environment (example below for PCSE 5.4):
     Installing collected packages: pcse
     Successfully installed pcse-5.4.0
 
-If you are wondering what the difference between `pip` and `conda` are than have a look
+If you are wondering what the differences between `pip` and `conda` are, then have a look
 `here <https://stackoverflow.com/questions/20994716/what-is-the-difference-between-pip-and-conda#20994790>`_
 
-If you want to develop with or contribute to PCSE, than you should fork the `PCSE
-repository`_ on GitHub and get a local copy of PCSE using `git clone`. See the help on github_
+If you want to develop with or contribute to PCSE, then you should fork the `PCSE
+repository`_ on GitHub and get a local copy of PCSE using `git clone`. See the help on GitHub_
 and for Windows/Mac users the `GitHub Desktop`_ application.
 
 .. _GitHub Desktop: https://desktop.github.com/
@@ -197,7 +197,7 @@ well as in an SQLite database (pcse.db). This database can be found under
 PCSE for the first time. When you delete the database file manually it will be
 recreated next time you import PCSE.
 
-For running the internal tests of the PCSE package we need to start python and import pcse:
+For running the internal tests of the PCSE package we need to start Python and import pcse:
 
 .. code-block:: doscon
 
@@ -262,4 +262,3 @@ Moreover, SQLAlchemy may complain with a warning that can be safely ignored::
     Dialect sqlite+pysqlite does *not* support Decimal objects natively, and SQLAlchemy must
     convert from floating point - rounding errors and other issues may occur. Please consider
     storing Decimal numbers as strings or integers on this platform for lossless storage.
-

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -65,7 +65,7 @@ simulation::
 
 We can now use the pandas package to turn the simulation output into a
 dataframe which is much easier to handle and can be exported to different
-file types. For example an excel file which should look like this
+file types. For example an Excel file which should look like this
 :download:`downloads/wofost_results.xls`::
 
     >>> import pandas as pd

--- a/doc/reference_guide.rst
+++ b/doc/reference_guide.rst
@@ -756,7 +756,7 @@ with an example::
             self._connect_signal(self.handle_mysignal, mysignal)
 
         def handle_mysignal(self, arg1, arg2):
-            print "Value of arg1, arg2: %s, %s" % (arg1, arg2)
+            print("Value of arg1, arg2: %s, %s" % (arg1, arg2))
 
         def send_mysignal(self):
             self._send_signal(signal=mysignal, arg2="A", arg1=2.5)
@@ -902,7 +902,7 @@ While individual weather elements can be accessed through the standard dotted py
 Finally, for convenience the WeatherDataProvider can also be called with a string representing a date.
 This string can in the format YYYYMMDD or YYYYDDD::
 
-    >>> print wdp("20060703")
+    >>> print(wdp("20060703"))
     Weather data for 2006-07-03 (DAY)
     IRRAD:  29290000.00  J/m2/day
      TMIN:        17.20   Celsius
@@ -919,7 +919,7 @@ This string can in the format YYYYMMDD or YYYYDDD::
 
 or in the format YYYYDDD::
 
-    >>> print wdp("2006183")
+    >>> print(wdp("2006183"))
     Weather data for 2006-07-03 (DAY)
     IRRAD:  29290000.00  J/m2/day
      TMIN:        17.20   Celsius

--- a/doc/reference_guide.rst
+++ b/doc/reference_guide.rst
@@ -521,7 +521,7 @@ An example of an agromanagement definition file::
 Crop calendars
 --------------
 
-The crop calendar definition will be passed on to a `CropCalendar` object which is 
+The crop calendar definition will be passed on to a `CropCalendar` object which is
 responsible for storing, checking, starting and ending the crop cycle during a PCSE simulation.
 At each time step the instance of `CropCalendar` is called
 and at the dates defined by its parameters it initiates the appropriate actions:
@@ -743,7 +743,7 @@ simulation, etc.
 Signals in PCSE are defined in the `signals` module which can be easily imported by
 any module that needs access to signals. Signals are simply defined as strings but
 any hashable object type would do. Most of the work for dealing with signals is in
-setting up a receiver. A receiver is usually a method on a SimulationObject that 
+setting up a receiver. A receiver is usually a method on a SimulationObject that
 will be called when the signal is broadcasted. This method will then be connected
 to the signal during the initialization of the object. This is easy to describe
 with an example::
@@ -974,7 +974,7 @@ for running crop rotations with different crop types as the data provider
 can switch the active crop.
 
 The most basic use is to call YAMLCropDataProvider with no parameters. It will
-than pull the crop parameters from the github repository at
+then pull the crop parameters from the GitHub repository at
 https://github.com/ajwdewit/WOFOST_crop_parameters::
 
     >>> from pcse.fileinput import YAMLCropDataProvider
@@ -982,7 +982,7 @@ https://github.com/ajwdewit/WOFOST_crop_parameters::
     >>> print(p)
     YAMLCropDataProvider - crop and variety not set: no activate crop parameter set!
 
-All crops and varieties have been loaded from the github repository, however no active
+All crops and varieties have been loaded from the GitHub repository, however no active
 crop has been set. Therefore, we can activate a particular crop and variety:
 
     >>> p.set_active_crop('wheat', 'Winter_wheat_101')
@@ -1018,12 +1018,12 @@ Additionally, it is possible to load YAML parameter files from your local file s
     >>> print(p)
     YAMLCropDataProvider - crop and variety not set: no activate crop parameter set!
 
-Finally, it is possible to pull data from your fork of my github repository by specifying
+Finally, it is possible to pull data from your fork of my GitHub repository by specifying
 the URL to that repository::
 
     >>> p = YAMLCropDataProvider(repository="https://raw.githubusercontent.com/<your_account>/WOFOST_crop_parameters/master/")
 
-Note that this URL should point to the location where the raw files can be found. In case of github, these URLs
+Note that this URL should point to the location where the raw files can be found. In case of GitHub, these URLs
 start with `https://raw.githubusercontent`, for other systems (e.g. gitlab) check the manual.
 
 To increase performance of loading parameters, the YAMLCropDataProvider will create a

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -41,7 +41,7 @@ What's new in PCSE 5.3
 PCSE 5.3 has the following new features:
 
 - The WOFOST crop parameters have been reorganized into a new data structure and file format (e.g. YAML)
-  and are available from github_. PCSE 5.3 provides the :ref:`YAMLCropDataProvider <YAMLCropDataProvider>`
+  and are available from GitHub_. PCSE 5.3 provides the :ref:`YAMLCropDataProvider <YAMLCropDataProvider>`
   to read the new parameters files. The YAMLCropDataProvider works together with the AgroManager for
   specifying parameter sets for crop rotations.
 - A new :ref:`CGMSEngine <Engine and models>` that mimics the behaviour of the classic CGMS. This means
@@ -57,7 +57,7 @@ Some bugs have been fixed:
 - When running crop rotations it was found that python did not garbage collect the crop simulation objects
   quick enough. This is now fixed with an explicit call to the garbage collector.
 
-.. _github: https://github.com/ajwdewit/WOFOST_crop_parameters
+.. _GitHub: https://github.com/ajwdewit/WOFOST_crop_parameters
 
 **********************
 What's new in PCSE 5.2

--- a/pcse/base/engine.py
+++ b/pcse/base/engine.py
@@ -41,7 +41,7 @@ class BaseEngine(HasTraits, DispatcherObject):
         #   these class methods are not defined attributes.
         #
         # Finally, if the value assigned to an attribute is a SimulationObject
-        #   or if the existing attribute value is a SimulationObject than
+        #   or if the existing attribute value is a SimulationObject, then
         #   rebuild the list of sub-SimulationObjects.
 
         if attr.startswith("_") or type(value) is types.FunctionType:

--- a/pcse/base/parameter_providers.py
+++ b/pcse/base/parameter_providers.py
@@ -206,8 +206,8 @@ class ParameterProvider(MutableMapping):
         """Override an existing parameter (key) by value.
 
          The parameter that is overridden is added to self._override, note that only *existing*
-         parameters may be overridden this way. If it is needed to really add a *new* parameter
-         than use: ParameterProvider.set_override(key, value, check=False)
+         parameters may be overridden this way. If it is needed to really add a *new* parameter,
+         then use: ParameterProvider.set_override(key, value, check=False)
 
         :param key: The name of the parameter to override
         :param value: the value of the parameter
@@ -266,4 +266,3 @@ class MultiCropDataProvider(dict):
         msg = "'set_crop_type' method should be implemented specifically for each" \
               "subclass of MultiCropDataProvider."
         raise NotImplementedError(msg)
-

--- a/pcse/base/simulationobject.py
+++ b/pcse/base/simulationobject.py
@@ -85,7 +85,7 @@ class SimulationObject(HasTraits, DispatcherObject):
         #   these class methods are not defined attributes.
         #
         # Finally, if the value assigned to an attribute is a SimulationObject
-        #   or if the existing attribute value is a SimulationObject than
+        #   or if the existing attribute value is a SimulationObject, then
         #   rebuild the list of sub-SimulationObjects.
 
         if attr.startswith("_") or type(value) is types.FunctionType:

--- a/pcse/base/states_rates.py
+++ b/pcse/base/states_rates.py
@@ -242,9 +242,9 @@ class StatesTemplate(StatesRatesCommon):
         ...
         >>> s1 = StateVariables(k, StateA=0., StateB=78, StateC=date(2003,7,3),
         ...                     publish="StateC")
-        >>> print s1.StateA, s1.StateB, s1.StateC
+        >>> print(s1.StateA, s1.StateB, s1.StateC)
         0.0 78 2003-07-03
-        >>> print k
+        >>> print(k)
         Contents of VariableKiosk:
          * Registered state variables: 3
          * Published state variables: 1 with values:

--- a/pcse/base/states_rates.py
+++ b/pcse/base/states_rates.py
@@ -52,7 +52,7 @@ class ParamTemplate(HasTraits):
         HasTraits.__init__(self)
 
         for parname in self.trait_names():
-            # If the attribute of the class starts with "trait" than
+            # If the attribute of the class starts with "trait", then
             # this is a special attribute and not a WOFOST parameter
             if parname.startswith("trait"):
                 continue

--- a/pcse/base/variablekiosk.py
+++ b/pcse/base/variablekiosk.py
@@ -43,7 +43,7 @@ class VariableKiosk(dict):
         >>> v.set_variable(id0, "VAR1", 1.35)
         >>> v.set_variable(id1, "VAR3", 310.56)
         >>>
-        >>> print v
+        >>> print(v)
         Contents of VariableKiosk:
          * Registered state variables: 2
          * Published state variables: 1 with values:
@@ -52,7 +52,7 @@ class VariableKiosk(dict):
          * Published rate variables: 1 with values:
           - variable VAR3, value: 310.56
 
-        >>> print v["VAR3"]
+        >>> print(v["VAR3"])
         310.56
         >>> v.set_variable(id0, "VAR3", 750.12)
         Traceback (most recent call last):
@@ -62,7 +62,7 @@ class VariableKiosk(dict):
         pcse.exceptions.VariableKioskError: Unregistered object tried to set the value of variable 'VAR3': access denied.
         >>>
         >>> v.flush_rates()
-        >>> print v
+        >>> print(v)
         Contents of VariableKiosk:
          * Registered state variables: 2
          * Published state variables: 1 with values:
@@ -72,7 +72,7 @@ class VariableKiosk(dict):
           - variable VAR3, value: undefined
 
         >>> v.flush_states()
-        >>> print v
+        >>> print(v)
         Contents of VariableKiosk:
          * Registered state variables: 2
          * Published state variables: 1 with values:
@@ -156,7 +156,7 @@ class VariableKiosk(dict):
         :param varname: Name of the variable to be registered, e.g. "DVS"
         """
         if varname in self.registered_states:
-            # print "Deregistering '%s'" % varname
+            # print("Deregistering '%s'" % varname)
             if oid != self.registered_states[varname]:
                 msg = "Wrong object tried to deregister variable '%s'." \
                       % varname
@@ -166,7 +166,7 @@ class VariableKiosk(dict):
             if varname in self.published_states:
                 self.published_states.pop(varname)
         elif varname in self.registered_rates:
-            # print "Deregistering '%s'" % varname
+            # print("Deregistering '%s'" % varname)
             if oid != self.registered_rates[varname]:
                 msg = "Wrong object tried to deregister variable '%s'." \
                       % varname

--- a/pcse/crop/leaf_dynamics.py
+++ b/pcse/crop/leaf_dynamics.py
@@ -14,7 +14,7 @@ from .. import signals
 
 class WOFOST_Leaf_Dynamics(SimulationObject):
     """Leaf dynamics for the WOFOST crop model.
-    
+
     Implementation of biomass partitioning to leaves, growth and senenscence
     of leaves. WOFOST keeps track of the biomass that has been partitioned to
     the leaves for each day (variable `LV`), which is called a leaf class).
@@ -23,12 +23,12 @@ class WOFOST_Leaf_Dynamics(SimulationObject):
     calculated by summing the biomass values for all leaf classes. Similarly,
     leaf area is calculated by summing leaf biomass times specific leaf area
     (`LV` * `SLA`).
-    
+
     Senescense of the leaves can occur as a result of physiological age,
     drought stress or self-shading.
-       
+
     *Simulation parameters* (provide in cropdata dictionary)
-    
+
     =======  ============================================= =======  ============
      Name     Description                                   Type     Unit
     =======  ============================================= =======  ============
@@ -82,24 +82,24 @@ class WOFOST_Leaf_Dynamics(SimulationObject):
              rate.
     FYSAGE   Increase in physiological leaf age                 N   -
     GLAIEX   Sink-limited leaf expansion rate (exponential      N   |ha ha-1 d-1|
-             curve) 
+             curve)
     GLASOL   Source-limited leaf expansion rate (biomass        N   |ha ha-1 d-1|
              increase)
     =======  ================================================= ==== ============
 
-    
+
     *External dependencies:*
-    
+
     ======== ============================== =============================== ===========
      Name     Description                         Provided by               Unit
     ======== ============================== =============================== ===========
-    DVS      Crop development stage         DVS_Phenology                    - 
+    DVS      Crop development stage         DVS_Phenology                    -
     FL       Fraction biomass to leaves     DVS_Partitioning                 -
     FR       Fraction biomass to roots      DVS_Partitioning                 -
     SAI      Stem area index                WOFOST_Stem_Dynamics             -
     PAI      Pod area index                 WOFOST_Storage_Organ_Dynamics    -
     TRA      Transpiration rate             Evapotranspiration              |cm day-1|
-    TRAMX    Maximum transpiration rate     Evapotranspiration              |cm day-1| 
+    TRAMX    Maximum transpiration rate     Evapotranspiration              |cm day-1|
     ADMI     Above-ground dry matter        CropSimulation                  |kg ha-1 d-1|
              increase
     RF_FROST Reduction factor frost kill    FROSTOL                          -
@@ -262,7 +262,7 @@ class WOFOST_Leaf_Dynamics(SimulationObject):
         tDRLV = rates.DRLV
 
         # leaf death is imposed on leaves by removing leave classes from the
-        # right side of the deque. 
+        # right side of the deque.
         for LVweigth in reversed(states.LV):
             if tDRLV > 0.:
                 if tDRLV >= LVweigth: # remove complete leaf class from deque
@@ -352,18 +352,18 @@ class WOFOST_Leaf_Dynamics(SimulationObject):
 
 class CSDM_Leaf_Dynamics(SimulationObject):
     """Leaf dynamics according to the Canopy Structure Dynamic Model.
-    
+
     The only difference is that in the real CSDM the temperature sum is the
     driving variable, while in this case it is simply the day number since \
     the start of the model.
-    
+
     Reference:
     Koetz et al. 2005. Use of coupled canopy structure dynamic and radiative
     transfer models to estimate biophysical canopy characteristics.
     Remote Sensing of Environment. Volume 95, Issue 1, 15 March 2005,
     Pages 115-124. http://dx.doi.org/10.1016/j.rse.2004.11.017
 
-        
+
     For plotting the CSDM model with GNUPLOT the following example code can be used:
 
         td = 150
@@ -377,7 +377,7 @@ class CSDM_Leaf_Dynamics(SimulationObject):
         set xrange [0:200]
         set yrange [-1:8]
         plot CSDM_MIN + CSDM_MAX*(1./(1. + exp(-CSDM_B*(x - CSDM_T1)))**2 - exp(CSDM_A*(x - CSDM_T2)))
-    
+
     """
 
     class Parameters(ParamTemplate):
@@ -403,9 +403,9 @@ class CSDM_Leaf_Dynamics(SimulationObject):
         LAI_senescence = -exp(p.CSDM_A*(daynr - p.CSDM_T2))
         LAI = p.CSDM_MIN + p.CSDM_MAX*(LAI_growth + LAI_senescence)
 
-        # do not allow LAI lower then CSDM_MIN
+        # Do not allow LAI lower than CSDM_MIN
         if LAI < p.CSDM_MIN:
-            msg = ("LAI of CSDM model smaller then lower LAI limit "+
+            msg = ("LAI of CSDM model smaller than lower LAI limit "+
                    "(CSDM_MIN)! Adjusting LAI to CSDM_MIN.")
             self.logger.warn(msg)
             LAI = max(p.CSDM_MIN, LAI)
@@ -563,7 +563,7 @@ class WOFOST_Leaf_Dynamics_NPK(SimulationObject):
         KDIFTB = AfgenTrait()
         RDRLV_NPK = Float(-99.)  # max. relative death rate of leaves due to nutrient NPK stress
         NSLA_NPK = Float(-99.)  # coefficient for the effect of nutrient NPK stress on SLA reduction
-        NLAI_NPK = Float(-99.)  # coefficient for the reduction due to nutrient NPK stress of the 
+        NLAI_NPK = Float(-99.)  # coefficient for the reduction due to nutrient NPK stress of the
                                   # LAI increase (during juvenile phase)
 
     class StateVariables(StatesTemplate):

--- a/pcse/crop/nutrients/npk_stress.py
+++ b/pcse/crop/nutrients/npk_stress.py
@@ -5,7 +5,7 @@
 """
 Class to calculate various nutrient relates stress factors:
     NNI      nitrogen nutrition index   
-    PNI      phosphorous nutrition index
+    PNI      phosphorus nutrition index
     KNI      potassium nutrition index
     NPKI     NPK nutrition index (= minimum of N/P/K-index)
     NPKREF   assimilation reduction factor based on NPKI
@@ -43,7 +43,7 @@ class NPK_Stress(SimulationObject):
     with subscript `a`, `r` and `c` being the actual, residual and critical
     concentration for the nutrient.
     This equation is applied in analogue to N, P and K and results in the
-    nitrogen nutrition index (NNI), phosphorous nutrition index (PNI) and
+    nitrogen nutrition index (NNI), phosphorus nutrition index (PNI) and
     Potassium nutrition index (KNI). Next, the NPK index (NPKI) is calculated
     as the minimum of NNI, PNI, KNI. Finally, the reduction factor for
     assimilation (NPKREF) is calculated using the reduction factor for

--- a/pcse/crop/respiration.py
+++ b/pcse/crop/respiration.py
@@ -8,18 +8,18 @@ from ..util import AfgenTrait
 
 class WOFOST_Maintenance_Respiration(SimulationObject):
     """Maintenance respiration in WOFOST
-    
+
     WOFOST calculates the maintenance respiration as proportional to the dry
     weights of the plant organs to be maintained, where each plant organ can be
     assigned a different maintenance coefficient. Multiplying organ weight
     with the maintenance coeffients yields the relative maintenance respiration
-    (`RMRES`) which is than corrected for senescence (parameter `RFSETB`). Finally,
+    (`RMRES`) which is then corrected for senescence (parameter `RFSETB`). Finally,
     the actual maintenance respiration rate is calculated using the daily mean
     temperature, assuming a relative increase for each 10 degrees increase
     in temperature as defined by `Q10`.
 
     **Simulation parameters:** (To be provided in cropdata dictionary):
-    
+
     =======  ============================================= =======  ============
      Name     Description                                   Type     Unit
     =======  ============================================= =======  ============
@@ -35,10 +35,10 @@ class WOFOST_Maintenance_Respiration(SimulationObject):
     RMO      Relative maintenance respiration rate for
              storage organs                                 SCr     |kg CH2O kg-1 d-1|
     =======  ============================================= =======  ============
-    
+
 
     **State and rate variables:**
-    
+
     `WOFOSTMaintenanceRespiration` returns the potential maintenance respiration PMRES
      directly from the `__call__()` method, but also includes it as a rate variable
      within the object.
@@ -52,11 +52,11 @@ class WOFOST_Maintenance_Respiration(SimulationObject):
     =======  ================================================ ==== =============
 
     **Signals send or handled**
-    
+
     None
-    
+
     **External dependencies:**
-    
+
     =======  =================================== =============================  ============
      Name     Description                         Provided by                    Unit
     =======  =================================== =============================  ============
@@ -69,7 +69,7 @@ class WOFOST_Maintenance_Respiration(SimulationObject):
 
 
     """
-    
+
     class Parameters(ParamTemplate):
         Q10 = Float(-99.)
         RMR = Float(-99.)
@@ -92,11 +92,11 @@ class WOFOST_Maintenance_Respiration(SimulationObject):
         self.params = self.Parameters(parvalues)
         self.rates = self.RateVariables(kiosk)
         self.kiosk = kiosk
-        
+
     def __call__(self, day, drv):
         p = self.params
         kk = self.kiosk
-        
+
         RMRES = (p.RMR * kk["WRT"] +
                  p.RML * kk["WLV"] +
                  p.RMS * kk["WST"] +

--- a/pcse/db/cgms12/data_providers.py
+++ b/pcse/db/cgms12/data_providers.py
@@ -330,7 +330,7 @@ class AgroManagementDataProvider(list):
                     self.campaign_start_date = campaign_start
                 else:
                     msg = "Date (%s) specified by keyword 'campaign_start' in call to AgroManagementDataProvider " \
-                          "is later then crop_start_date defined in the CGMS database."
+                          "is later than crop_start_date defined in the CGMS database."
                     raise exc.PCSEError(msg % campaign_start)
             except KeyError as e:
                 msg = "Value (%s) of keyword 'campaign_start' not recognized in call to AgroManagementDataProvider."
@@ -344,7 +344,7 @@ class AgroManagementDataProvider(list):
             raise exc.PCSEError(msg)
 
         # Determine crop_end_date and campaign_end_date
-        # note that campaign_end_date should be at least one day later then crop_end_date
+        # note that campaign_end_date should be at least one day later than crop_end_date
         if self.crop_end_type == "maturity":
             self.crop_end_date = "null"
             self.max_duration = int(row.max_duration)

--- a/pcse/db/hdf5/hdf5_readers.py
+++ b/pcse/db/hdf5/hdf5_readers.py
@@ -368,7 +368,7 @@ class AgroManagementDataProvider(list):
                     self.campaign_start_date = campaign_start
                 else:
                     msg = "Date (%s) specified by keyword 'campaign_start' in call to AgroManagementDataProvider " \
-                          "is later then crop_start_date defined in the CGMS database."
+                          "is later than crop_start_date defined in the CGMS database."
                     raise exc.PCSEError(msg % campaign_start)
             except KeyError as e:
                 msg = "Value (%s) of keyword 'campaign_start' not recognized in call to AgroManagementDataProvider."
@@ -606,4 +606,3 @@ class SoilDataIterator(list):
         for t in self:
             msg += template % t
         return msg
-

--- a/pcse/db/nasapower.py
+++ b/pcse/db/nasapower.py
@@ -118,7 +118,7 @@ class NASAPowerWeatherDataProvider(WeatherDataProvider):
         else:
             # Cache file is too old. Try loading new data from NASA
             try:
-                msg = "Cache file older then 90 days, reloading data from NASA Power."
+                msg = "Cache file older than 90 days, reloading data from NASA Power."
                 self.logger.debug(msg)
                 self._get_and_process_NASAPower(self.latitude, self.longitude)
             except Exception as e:
@@ -177,7 +177,7 @@ class NASAPowerWeatherDataProvider(WeatherDataProvider):
         # check if sufficient data is available to make a reasonable estimate:
         # As a rule of thumb we want to have at least 200 days available
         if len(df_power) < 200:
-            msg = ("Less then 200 days of data available. Reverting to " +
+            msg = ("Less than 200 days of data available. Reverting to " +
                    "default Angstrom A/B coefficients (%f, %f)")
             self.logger.warn(msg % (self.angstA, self.angstB))
             return self.angstA, self.angstB

--- a/pcse/db/nasapower.py
+++ b/pcse/db/nasapower.py
@@ -23,11 +23,11 @@ to_date = lambda d: d.date()
 class NASAPowerWeatherDataProvider(WeatherDataProvider):
     """WeatherDataProvider for using the NASA POWER database with PCSE
 
-    :param latitude: latitude to request weather data for
-    :param longitude: longitude to request weather data for
+    :param latitude: latitude to request weather data for.
+    :param longitude: longitude to request weather data for.
     :keyword force_update: Set to True to force to request fresh data
         from POWER website.
-    :keyword ETmodel: "PM"|"P" for selecting penman-monteith or Penman
+    :keyword ETmodel: "PM"|"P" for selecting Penman-Monteith or Penman
         method for reference evapotranspiration. Defaults to "PM".
 
     The NASA POWER database is a global database of daily weather data

--- a/pcse/db/nasapower.py
+++ b/pcse/db/nasapower.py
@@ -46,13 +46,13 @@ class NASAPowerWeatherDataProvider(WeatherDataProvider):
     at: http://power.larc.nasa.gov/common/AgroclimatologyMethodology/Agro_Methodology_Content.html
 
     The `NASAPowerWeatherDataProvider` retrieves the weather from the
-    th NASA POWER API and does the necessary conversions to be compatible
+    NASA POWER API and does the necessary conversions to be compatible
     with PCSE. After the data has been retrieved and stored, the contents
     are dumped to a binary cache file. If another request is made for the
     same location, the cache file is loaded instead of a full request to the
     NASA Power server.
 
-    Cache files are used until they are older then 90 days. After 90 days
+    Cache files are used until they are older than 90 days. After 90 days
     the NASAPowerWeatherDataProvider will make a new request to obtain
     more recent data from the NASA POWER server. If this request fails
     it will fall back to the existing cache file. The update of the cache
@@ -60,7 +60,7 @@ class NASAPowerWeatherDataProvider(WeatherDataProvider):
 
     Finally, note that any latitude/longitude within a 0.5x0.5 degrees grid box
     will yield the same weather data, e.g. there is no difference between
-    lat/lon 5.3/52.1 and lat/lon 5.1/52.4. Nevertheless slight differences
+    lat/lon 5.3/52.1 and lat/lon 5.1/52.4. Nevertheless, slight differences
     in PCSE simulations may occur due to small differences in day length.
 
     """

--- a/pcse/db/nasapower.py
+++ b/pcse/db/nasapower.py
@@ -43,7 +43,7 @@ class NASAPowerWeatherDataProvider(WeatherDataProvider):
     WOFOST in the past.
 
     For more information on the NASA POWER database see the documentation
-    at: http://power.larc.nasa.gov/common/AgroclimatologyMethodology/Agro_Methodology_Content.html
+    at: https://power.larc.nasa.gov/docs/methodology/
 
     The `NASAPowerWeatherDataProvider` retrieves the weather from the
     NASA POWER API and does the necessary conversions to be compatible

--- a/pcse/db/pcse/db_input.py
+++ b/pcse/db/pcse/db_input.py
@@ -457,7 +457,7 @@ def fetch_soildata_layered(metadata, grid):
         
     soildata["SOIL_LAYERS"]= soil_layers
     
-    #print "Succesfully retrieved soil layer parameter values for layered soil from database"
+    #print("Succesfully retrieved soil layer parameter values for layered soil from database")
     logger.info("Succesfully retrieved soil layer parameter values for layered soil from database")
 
     return soildata

--- a/pcse/decorators.py
+++ b/pcse/decorators.py
@@ -8,13 +8,13 @@ class descript(object):
     def __init__(self, f, lockattr):
         self.f = f
         self.lockattr = lockattr
-    
+
     def __get__(self, instance, klass):
         if instance is None:
             # Class method was requested
             return self.make_unbound(klass)
         return self.make_bound(instance)
-    
+
     def make_unbound(self, klass):
         @wraps(self.f)
         def wrapper(*args, **kwargs):
@@ -26,13 +26,13 @@ class descript(object):
                 (self.f.__name__, klass.__name__)
             )
         return wrapper
-    
+
     def make_bound(self, instance):
         @wraps(self.f)
         def wrapper(*args, **kwargs):
             '''This documentation will disapear :)'''
-            #print "Called the decorated method %r of %r with arguments %s "\
-            #      %(self.f.__name__, instance, args)
+            #print("Called the decorated method %r of %r with arguments %s "\
+            #      %(self.f.__name__, instance, args))
             attr = getattr(instance, self.lockattr)
             if attr is not None:
                 attr.unlock()
@@ -50,7 +50,7 @@ def prepare_states(f):
     '''
     Class method decorator unlocking and locking the states object.
 
-    It uses a descriptor to delay the definition of the 
+    It uses a descriptor to delay the definition of the
     method wrapper. For more details:
     http://wiki.python.org/moin/PythonDecoratorLibrary#Class_method_decorator_using_instance
     '''
@@ -61,7 +61,7 @@ def prepare_rates(f):
     '''
     Class method decorator unlocking and locking the rates object.
 
-    It uses a descriptor to delay the definition of the 
+    It uses a descriptor to delay the definition of the
     method wrapper. For more details:
     http://wiki.python.org/moin/PythonDecoratorLibrary#Class_method_decorator_using_instance
     '''
@@ -75,22 +75,22 @@ def main():
                 print("Locking!")
             def unlock(self):
                 print("Unlocking!")
-    
+
         def __init__(self):
             self.myattr = 10
             self.rates = self.strates()
             self.states = self.strates()
-        
+
         @prepare_states
         def integrate(self, a, b, c):
             print("executing _integrate with parameters %s,%s,%s!" % (a, b, c))
         @prepare_rates
         def calc_rates(self, a, b, c):
             print("executing _calc_rates with parameters %s,%s,%s!" % (a, b, c))
-            
-            
+
+
     tc = testclass()
-    
+
     tc.integrate(1, 2, 3)
     tc.calc_rates(4, 5, 6)
 

--- a/pcse/fileinput/cabo_reader.py
+++ b/pcse/fileinput/cabo_reader.py
@@ -13,10 +13,10 @@ class LengthError(PCSEError):
 
 class DuplicateError(PCSEError):
     pass
-    
+
 class CABOFileReader(dict):
     """Reads CABO files with model parameter definitions.
-    
+
     The parameter definitions of Wageningen crop models are generally
     written in the CABO format. This class reads the contents, parses
     the parameter names/values and returns them as a dictionary.
@@ -31,32 +31,32 @@ class CABOFileReader(dict):
     The header of the CABO file (marked with ** at the first line) is
     read and can be retrieved by the get_header() method or just by
     a print on the returned dictionary.
-    
+
     *Example*
-    
+
     A parameter file 'parfile.cab' which looks like this::
-    
+
         ** CROP DATA FILE for use with WOFOST Version 5.4, June 1992
         **
         ** WHEAT, WINTER 102
-        ** Regions: Ireland, central en southern UK (R72-R79), 
+        ** Regions: Ireland, central en southern UK (R72-R79),
         **          Netherlands (not R47), northern Germany (R11-R14)
         CRPNAM='Winter wheat 102, Ireland, N-U.K., Netherlands, N-Germany'
         CROP_NO=99
         TBASEM   = -10.0    ! lower threshold temp. for emergence [cel]
-        DTSMTB   =   0.00,    0.00,     ! daily increase in temp. sum 
+        DTSMTB   =   0.00,    0.00,     ! daily increase in temp. sum
                     30.00,   30.00,     ! as function of av. temp. [cel; cel d]
                     45.00,   30.00
         ** maximum and minimum concentrations of N, P, and K
         ** in storage organs        in vegetative organs [kg kg-1]
         NMINSO   =   0.0110 ;       NMINVE   =   0.0030
-    
+
     Can be read with the following statements::
-    
+
         >>>fileparameters = CABOFileReader('parfile.cab')
-        >>>print fileparameters['CROP_NO']
+        >>>print(fileparameters['CROP_NO'])
         99
-        >>>print fileparameters
+        >>>print(fileparameters)
         ** CROP DATA FILE for use with WOFOST Version 5.4, June 1992
         **
         ** WHEAT, WINTER 102
@@ -83,7 +83,7 @@ class CABOFileReader(dict):
             if len(line)>0:
                 t.append(line)
         return t
-        
+
     def _remove_inline_comments(self, filecontents):
         t = []
         for line in filecontents:
@@ -92,7 +92,7 @@ class CABOFileReader(dict):
             if len(line) > 0:
                 t.append(line)
         return t
-    
+
     def _is_comment(self, line):
         if line.startswith("*"):
             return True
@@ -100,7 +100,7 @@ class CABOFileReader(dict):
             return False
 
     def _find_header(self, filecontents):
-        """Parses and strips header marked with '*' at the beginning of 
+        """Parses and strips header marked with '*' at the beginning of
         the file. Further lines marked with '*' are deleted."""
 
         header = []
@@ -119,7 +119,7 @@ class CABOFileReader(dict):
                 else:
                     other_contents.append(line)
         return (header, other_contents)
- 
+
     def _parse_table_values(self, parstr):
         """Parses table parameter into a list of floats."""
 
@@ -135,13 +135,13 @@ class CABOFileReader(dict):
             value = float(vstr)
             tblvalues.append(value)
         return tblvalues
-        
+
     def _find_parameter_sections(self, filecontents):
         "returns the sections defining float, string and table parameters."
         scalars = ""
         strings = ""
         tables = ""
-        
+
         for line in filecontents:
             if line.find("'") != -1: # string parameter
                 strings += (line + " ")
@@ -149,9 +149,9 @@ class CABOFileReader(dict):
                 tables += (line + " ")
             else:
                 scalars += (line + " ")
-                
+
         return scalars, strings, tables
-       
+
     def _find_individual_pardefs(self, regexp, parsections):
         """Splits the string into individual parameters definitions.
         """
@@ -164,7 +164,7 @@ class CABOFileReader(dict):
                   ("Failed to parse:\n %s" % rest)
             raise PCSEError(msg)
         return par_definitions
-        
+
     def __init__(self, fname):
         with open(fname) as fp:
             filecontents = fp.readlines()
@@ -197,7 +197,7 @@ class CABOFileReader(dict):
                     value = int(valuestr)
                 self[parname] = value
             except (ValueError) as exc:
-                msg = "Failed to parse parameter, value: %s, %s" 
+                msg = "Failed to parse parameter, value: %s, %s"
                 raise PCSEError(msg % (parstr, valuestr))
 
         for parstr in string_defs:
@@ -207,7 +207,7 @@ class CABOFileReader(dict):
                 value = (valuestr.replace("'","")).replace('"','')
                 self[parname] = value
             except (ValueError) as exc:
-                msg = "Failed to parse parameter, value: %s, %s" 
+                msg = "Failed to parse parameter, value: %s, %s"
                 raise PCSEError(msg % (parstr, valuestr))
 
         for parstr in table_defs:
@@ -222,7 +222,7 @@ class CABOFileReader(dict):
             except (LengthError) as exc:
                 msg = "Failed to parse table parameter %s: %s. \n" % (parname, valuestr)
                 msg += "Table parameter should contain at least 4 values "
-                msg += "instead got %i" 
+                msg += "instead got %i"
                 raise PCSEError(msg % exc.value[0])
             except (XYPairsError) as exc:
                 msg = "Failed to parse table parameter %s: %s\n" % (parname, valuestr)

--- a/pcse/fileinput/cabo_reader.py
+++ b/pcse/fileinput/cabo_reader.py
@@ -29,7 +29,7 @@ class CABOFileReader(dict):
     tabular parameters is not supported and will lead to errors.
 
     The header of the CABO file (marked with ** at the first line) is
-    read and can be retrieved by the get_header() method or just by
+    read and can be retrieved from the .header attribute or just by
     a print on the returned dictionary.
 
     *Example*

--- a/pcse/fileinput/cabo_reader.py
+++ b/pcse/fileinput/cabo_reader.py
@@ -21,7 +21,7 @@ class CABOFileReader(dict):
     written in the CABO format. This class reads the contents, parses
     the parameter names/values and returns them as a dictionary.
 
-    :param fname: parameter file to read and parse
+    :param fname: parameter file to read and parse.
     :returns: dictionary like object with parameter key/value pairs.
 
     Note that this class does not yet fully support reading all features

--- a/pcse/fileinput/cabo_weather.py
+++ b/pcse/fileinput/cabo_weather.py
@@ -136,7 +136,7 @@ class CABOWeatherDataProvider(WeatherDataProvider):
     def _load_cache_file(self, cache_file, CABOWE_files):
         """Load the weather data from a binary file using cPickle.
 
-        Also checks if any of the CABOWE files have modification/creation date more recent then the cache_file.
+        Also checks if any of the CABOWE files have modification/creation date more recent than the cache_file.
         In that case reload the weather data from the original CABOWE files.
 
         Returns True if loading succeeded, False otherwise

--- a/pcse/fileinput/cabo_weather.py
+++ b/pcse/fileinput/cabo_weather.py
@@ -14,7 +14,7 @@ from ..exceptions import PCSEError
 
 class CABOWeatherDataProvider(WeatherDataProvider):
     """Reader for CABO weather files.
-    
+
     :param fname: root name of CABO weather files to read
     :param fpath: path where to find files, can be absolute or relative.
     :keyword ETmodel: "PM"|"P" for selecting penman-monteith or Penman
@@ -22,7 +22,7 @@ class CABOWeatherDataProvider(WeatherDataProvider):
     :keyword distance: maximum interpolation distance for meteorological
         variables, defaults to 1 day.
     :returns: callable like object with meteo records keyed on date.
-    
+
     The Wageningen crop models that are written in FORTRAN or FST often use
     the CABO weather system (http://edepot.wur.nl/43010) for storing and
     reading weather data. This class implements a reader for the CABO weather
@@ -31,28 +31,28 @@ class CABOWeatherDataProvider(WeatherDataProvider):
     to global radiation estimates and calculation the reference
     evapotranspiration values for water, soil and plants (E0, ES0, ET0)
     using the Penman approach.
-    
+
     A difference with the old CABOWE system is that the python implementation
     will read and store all files (e.g. years) available for a certain
     station instead of loading a new file when crossing a year boundary.
-    
+
     .. note::
         some conversions are done by the CABOWeaterDataProvider from
         the units in the CABO weather file for compatibility with WOFOST:
-        
+
         - vapour pressure from kPa to hPa
         - radiation from kJ/m2/day to J/m2/day
         - rain from mm/day to cm/day.
         - all evaporation/transpiration rates are also returned in cm/day.
-    
+
     *Example*
-    
+
     The file 'nl1.003' provides weather data for the year 2003 for the
     station in Wageningen and can be found in the cabowe/ folder of the
     WOFOST model distribution. This file can be read using::
-    
+
         >>> weather_data = CABOWeatherDataProvider('nl1', fpath="./meteo/cabowe")
-        >>> print weather_data(datetime.date(2003,7,26))
+        >>> print(weather_data(datetime.date(2003,7,26)))
         Weather data for 2003-07-26 (DAY)
         IRRAD:  12701000.00  J/m2/day
          TMIN:        15.90   Celsius
@@ -87,7 +87,7 @@ class CABOWeatherDataProvider(WeatherDataProvider):
     # temporary array for storing data
     potential_records = None
     tmp_data = None
-    
+
     def __init__(self, fname, fpath=None, ETmodel="PM", distance=1):
         WeatherDataProvider.__init__(self)
 
@@ -138,7 +138,7 @@ class CABOWeatherDataProvider(WeatherDataProvider):
 
         Also checks if any of the CABOWE files have modification/creation date more recent then the cache_file.
         In that case reload the weather data from the original CABOWE files.
-        
+
         Returns True if loading succeeded, False otherwise
         """
         # If no cache_file defined return False directly
@@ -200,7 +200,7 @@ class CABOWeatherDataProvider(WeatherDataProvider):
         except (ValueError,IndexError) as exc:
             msg = ("Failed to parse line: %s" % rec)
             raise RuntimeError(msg)
-        
+
         # Check if file contents are consistent with file year
         if year != fileyr:
             msg = "File with year %s contains record for year %s"
@@ -209,13 +209,13 @@ class CABOWeatherDataProvider(WeatherDataProvider):
         # Calculate position in tmp_array base on date since first date
         rec_date = dt.date(year, 1, 1) + dt.timedelta(days=(doy-1))
         arraypos = (rec_date - self.first_date).days
-        
+
         # insert data at right position in array
         self.tmp_data[:, arraypos] = weather_obs
-            
+
     def _interpolate_timeseries(self, distance=1):
         """Interpolates gaps using linear interpolation, except for rainfall.
-        
+
         distance specifies the interpolation distance: distance=1 will only
         allow interpolation when the previous and the following day are
         available, distance=2 allows also when 2 days are missing, etc.
@@ -246,7 +246,7 @@ class CABOWeatherDataProvider(WeatherDataProvider):
                 continue
             timeseries = self.tmp_data[i,:].flatten()
             r = np.convolve(timeseries_hasdata, kernel, mode='same')
-            
+
             # Find positions for interpolation: hasdata==0 and >=2 neighbours
             # except the first and last record
             index = (timeseries_hasdata==0)*(r>=2)
@@ -255,7 +255,7 @@ class CABOWeatherDataProvider(WeatherDataProvider):
             if True not in index:
                 # No positions that can be interpolated
                 continue
-                
+
             # Determine positions and y values for interpolation (x, xp, yp)
             xrange = np.arange(self.potential_records, dtype=np.float64)
             x  = xrange[index]
@@ -265,21 +265,21 @@ class CABOWeatherDataProvider(WeatherDataProvider):
 
             # put interpolated values back into tmp_data
             self.tmp_data[i, x.astype(np.int32)] = y_int
-    
+
 
     def _make_WeatherDataContainers(self):
         """Converts the data in self.tmp_data into WeatherDataContainers which are stored in
         the class dictionary keyed on the date.
-        
+
         Records that are incomplete (contain np.NaN values) are skipped.
         Moreover, if the radiation measurements are in sunshine duration, than
         the Angstrom equation is used to estimate global radiation. Finally,
         the evapotranspiration value are calculated for each complete record.
         """
-        
+
         # Generate prototype weather data container
         #wdc_proto = self._build_WeatherDataContainer()
-        
+
         for i in range(self.potential_records):
             rec = self.tmp_data[:, i]
             if True in np.isnan(rec):
@@ -288,9 +288,9 @@ class CABOWeatherDataProvider(WeatherDataProvider):
 
             # Derive date from position in array
             thisdate = self.first_date + dt.timedelta(days=i)
-            t = {"DAY": thisdate, "LAT": self.latitude, 
+            t = {"DAY": thisdate, "LAT": self.latitude,
                  "LON": self.longitude, "ELEV": self.elevation}
-            
+
             for obs, (name, cf, unit) in zip(rec, self.variables):
                 if name == "IRRAD" and self.has_sunshine is True:
                     obs = angstrom(thisdate, self.latitude, obs, self.angstA, self.angstB)
@@ -298,7 +298,7 @@ class CABOWeatherDataProvider(WeatherDataProvider):
                     t[name] = float(obs)
                 else:
                     t[name] = float(obs)*cf
-            
+
             # Reference evapotranspiration in mm/day
             try:
                 E0, ES0, ET0 = reference_ET(thisdate, t["LAT"], t["ELEV"], t["TMIN"], t["TMAX"], t["IRRAD"],
@@ -317,7 +317,7 @@ class CABOWeatherDataProvider(WeatherDataProvider):
 
             # add wdc to dictionary for thisdate
             self._store_WeatherDataContainer(wdc, thisdate)
-        
+
     def _calc_arraysize(self):
         """Returns array of NaNs with size based on min/max year of data."""
         self.potential_records = 0
@@ -328,7 +328,7 @@ class CABOWeatherDataProvider(WeatherDataProvider):
                 self.potential_records += 365
         t_ar = np.empty((6,self.potential_records), dtype=np.float64)
         t_ar[:] = np.NaN
-        
+
         return t_ar
 
     def _set_location_parameters(self, line, cb_file, prev_cb_file):
@@ -338,7 +338,7 @@ class CABOWeatherDataProvider(WeatherDataProvider):
         if len(strvalues) != 5:
             msg = "Did not find 5 values on location parameter line of file %s"
             raise PCSEError(msg % cb_file)
-        
+
         parnames = ["longitude", "latitude", "elevation", "angstA", "angstB"]
         for parname, strvalue in zip(parnames, strvalues):
             try:
@@ -355,21 +355,21 @@ class CABOWeatherDataProvider(WeatherDataProvider):
             except AttributeError as e:
                 msg = "Inconsistent '%s' location parameter in file %s compared to file %s."
                 raise PCSEError(msg % (parname, cb_file, prev_cb_file))
-    
+
     def _check_angstrom(self):
         """Checks the Angstrom parameters for consistency.
-        
+
         Also sets self.has_sunshine=True when both A and B > 0.
         """
         if self.angstA > 0 and self.angstB > 0:
             self.has_sunshine=True
-            
+
         self.angstA = abs(self.angstA)
         self.angstB = abs(self.angstB)
         check_angstromAB(self.angstA, self.angstB)
 
     def _read_file(self, fname):
-        
+
         with open(fname) as fp:
             lines = fp.readlines()
         header = []
@@ -385,14 +385,14 @@ class CABOWeatherDataProvider(WeatherDataProvider):
                 else:
                     records.append(l)
         return (header, location_par, records)
-    
+
     def _find_CABOWEfiles(self, search_path):
         """Find CABOWEfiles on given path with given name.
-        
+
         Also sorts the list, checks for missing years and sets self.firstyear/lastyear
         and self.first_date.
         """
-        
+
         cachefile = search_path + ".cache"
         if not os.path.exists(cachefile):
             cachefile = None

--- a/pcse/fileinput/cabo_weather.py
+++ b/pcse/fileinput/cabo_weather.py
@@ -15,9 +15,9 @@ from ..exceptions import PCSEError
 class CABOWeatherDataProvider(WeatherDataProvider):
     """Reader for CABO weather files.
 
-    :param fname: root name of CABO weather files to read
+    :param fname: root name of CABO weather files to read.
     :param fpath: path where to find files, can be absolute or relative.
-    :keyword ETmodel: "PM"|"P" for selecting penman-monteith or Penman
+    :keyword ETmodel: "PM"|"P" for selecting Penman-Monteith or Penman
         method for reference evapotranspiration. Defaults to "PM".
     :keyword distance: maximum interpolation distance for meteorological
         variables, defaults to 1 day.
@@ -52,7 +52,7 @@ class CABOWeatherDataProvider(WeatherDataProvider):
     WOFOST model distribution. This file can be read using::
 
         >>> weather_data = CABOWeatherDataProvider('nl1', fpath="./meteo/cabowe")
-        >>> print(weather_data(datetime.date(2003,7,26)))
+        >>> print(weather_data(datetime.date(2003, 7, 26)))
         Weather data for 2003-07-26 (DAY)
         IRRAD:  12701000.00  J/m2/day
          TMIN:        15.90   Celsius
@@ -145,8 +145,8 @@ class CABOWeatherDataProvider(WeatherDataProvider):
         if cache_file is None:
             return False
 
-        # if date of any CABOWE files > cache file: discard cache file and return False to reload from original files.
-        # retrieved last modification dates of CABOWE files
+        # If date of any CABOWE files > cache file: discard cache file and return False to reload from original files.
+        # retrieve last modification dates of CABOWE files
         cb_dates = []
         for cb_file in CABOWE_files:
             r = os.stat(cb_file)
@@ -160,8 +160,8 @@ class CABOWeatherDataProvider(WeatherDataProvider):
                 msg = "Failed to remove cache file '%s' due to: %s" % (cache_file, exc)
                 warnings.warn(msg)
             return False
+        # Else load data from cache file and store internally
         else:
-            # Else load data from cache file and store internally
             try:
                 self._load(cache_file)
                 return True
@@ -171,7 +171,7 @@ class CABOWeatherDataProvider(WeatherDataProvider):
                 return False
 
     def _write_cache_file(self, search_path):
-        """Write the data loaded from the CABOWE files to a binary file using cPickle
+        """Write the data loaded from the CABOWE files to a binary file using cPickle.
         """
         cache_fname = search_path + ".cache"
         self._dump(cache_fname)
@@ -197,7 +197,7 @@ class CABOWeatherDataProvider(WeatherDataProvider):
             year = int(values[1])
             doy  = int(values[2])
             weather_obs = np.array(values[3:], dtype=np.float64)
-        except (ValueError,IndexError) as exc:
+        except (ValueError, IndexError) as exc:
             msg = ("Failed to parse line: %s" % rec)
             raise RuntimeError(msg)
 
@@ -210,7 +210,7 @@ class CABOWeatherDataProvider(WeatherDataProvider):
         rec_date = dt.date(year, 1, 1) + dt.timedelta(days=(doy-1))
         arraypos = (rec_date - self.first_date).days
 
-        # insert data at right position in array
+        # Insert data at right position in array
         self.tmp_data[:, arraypos] = weather_obs
 
     def _interpolate_timeseries(self, distance=1):
@@ -263,7 +263,7 @@ class CABOWeatherDataProvider(WeatherDataProvider):
             yp = timeseries[(timeseries_hasdata == 1)]
             y_int = np.interp(x,xp,yp)
 
-            # put interpolated values back into tmp_data
+            # Put interpolated values back into tmp_data
             self.tmp_data[i, x.astype(np.int32)] = y_int
 
 
@@ -272,7 +272,7 @@ class CABOWeatherDataProvider(WeatherDataProvider):
         the class dictionary keyed on the date.
 
         Records that are incomplete (contain np.NaN values) are skipped.
-        Moreover, if the radiation measurements are in sunshine duration, than
+        Moreover, if the radiation measurements are in sunshine duration, then
         the Angstrom equation is used to estimate global radiation. Finally,
         the evapotranspiration value are calculated for each complete record.
         """
@@ -309,13 +309,13 @@ class CABOWeatherDataProvider(WeatherDataProvider):
                        ("Due to error: %s" % e))
                 raise PCSEError(msg)
 
-            # update record with ET values value convert to cm/day
+            # Update record with ET values value convert to cm/day
             t.update({"E0": E0/10., "ES0": ES0/10., "ET0": ET0/10.})
 
             # Build weather data container from dict 't'
             wdc = WeatherDataContainer(**t)
 
-            # add wdc to dictionary for thisdate
+            # Add wdc to dictionary for thisdate
             self._store_WeatherDataContainer(wdc, thisdate)
 
     def _calc_arraysize(self):

--- a/pcse/fileinput/csvweatherdataprovider.py
+++ b/pcse/fileinput/csvweatherdataprovider.py
@@ -38,7 +38,7 @@ class IRRADFromSunshineDuration:
         self.angstB = angstB
 
     def __call__(self, value, day):
-        """Computes irradiance in J/m2/day from sunshine duration by applying the Angstrom equation
+        """Computes irradiance in J/m2/day from sunshine duration by applying the Angstrom equation.
 
         :param value: sunshine duration in hours
         :param day: the day
@@ -81,12 +81,12 @@ def kPa_to_hPa(x, d):
 class CSVWeatherDataProvider(WeatherDataProvider):
     """Reading weather data from a CSV file.
 
-    :param csv_fname: name of the CSV file to be read
-    :param delimiter: CSV delimiter
-    :param dateformat: date format to be read. Default is '%Y%m%d'
+    :param csv_fname: name of the CSV file to be read.
+    :param delimiter: CSV delimiter.
+    :param dateformat: date format to be read. Default is '%Y%m%d'.
     :keyword ETmodel: "PM"|"P" for selecting Penman-Monteith or Penman
         method for reference evapotranspiration. Default is 'PM'.
-    :param force_reload: Ignore cache file and reload from the CSV file
+    :param force_reload: Ignore cache file and reload from the CSV file.
 
     The CSV file should have the following structure (sample), missing values should be added as 'NaN'::
 
@@ -114,11 +114,11 @@ class CSVWeatherDataProvider(WeatherDataProvider):
         RAIN in mm
         SNOWDEPTH in cm
 
-    For reading weather data from a file, initially the CABOWeatherDataProvider
-    was available which read its data from text in the CABO weather format.
-    Nevertheless, building CABO weather files is tedious as for each year a new
-    file must constructed. Moreover it is rather error prone and formatting
-    mistakes are easily leading to errors.
+    For reading weather data from file, initially only the CABOWeatherDataProvider
+    was available, which reads its data from a text file in the CABO Weather format.
+    However, building CABO weather files is tedious, as a new file must be
+    constructed for each year. Moreover, it is rather error-prone and formatting
+    mistakes easily lead to errors.
 
     To simplify providing weather data to PCSE models, a new data provider
     has been derived from the ExcelWeatherDataProvider that reads its data
@@ -211,7 +211,7 @@ class CSVWeatherDataProvider(WeatherDataProvider):
                 e0, es0, et0 = reference_ET(LAT=self.latitude, ELEV=self.elevation,
                                             ANGSTA=self.angstA, ANGSTB=self.angstB,
                                             ETMODEL=self.ETmodel, **row)
-                # convert to cm/day
+                # Convert to cm/day
                 row["E0"] = e0/10.
                 row["ES0"] = es0/10.
                 row["ET0"] = et0/10.
@@ -235,7 +235,7 @@ class CSVWeatherDataProvider(WeatherDataProvider):
             return True
 
     def _find_cache_file(self, csv_fname):
-        """Try to find a cache file for file name
+        """Try to find a cache file for file name.
 
         Returns None if the cache file does not exist, else it returns the full
         path to the cache file.
@@ -244,13 +244,13 @@ class CSVWeatherDataProvider(WeatherDataProvider):
         if os.path.exists(cache_filename):
             cache_date = os.stat(cache_filename).st_mtime
             csv_date = os.stat(csv_fname).st_mtime
-            if cache_date > csv_date:  # cache is more recent then CSV file
+            if cache_date > csv_date:  # cache is more recent than CSV file
                 return cache_filename
 
         return None
 
     def _get_cache_filename(self, csv_fname):
-        """Constructs the filename used for cache files given csv_fname
+        """Constructs the filename used for cache files given csv_fname.
         """
         basename = os.path.basename(csv_fname)
         filename, ext = os.path.splitext(basename)

--- a/pcse/fileinput/excelweatherdataprovider.py
+++ b/pcse/fileinput/excelweatherdataprovider.py
@@ -19,7 +19,7 @@ mm_to_cm = lambda x: x/10.
 
 
 def determine_true_false(value):
-    """OpenPyXL has a somewhat strange treatment of true/false
+    """OpenPyXL has a somewhat strange treatment of True/False:
 
     Excel cell value      OpenPyXL cell value       Type
        =FALSE()            '=FALSE()'               str
@@ -29,7 +29,7 @@ def determine_true_false(value):
        =TRUE               '=TRUE'                  str
        TRUE                 True                    bool
 
-    Finally, there is the possibility for true/false to be presented
+    Finally, there is the possibility for True/False to be presented
     by 0/1 integer values.
 
     This function tries to handle all of the them.
@@ -53,22 +53,22 @@ def determine_true_false(value):
 
 
 class ExcelWeatherDataProvider(WeatherDataProvider):
-    """Reading weather data from an excel file (.xlsx only).
+    """Reading weather data from an Excel file (.xlsx only).
 
-    :param xls_fname: name of the Excel file to be read
+    :param xls_fname: name of the Excel file to be read.
     :param mising_snow_depth: the value that should use for missing SNOW_DEPTH values,
            the default value is `None`.
     :param force_reload: bypass the cache file, reload data from the .xlsx file and
-           write a new cache file. Cache files are written under `$HOME/.pcse/meteo_cache`
+           write a new cache file. Cache files are written under `$HOME/.pcse/meteo_cache`.
 
     For reading weather data from file, initially only the CABOWeatherDataProvider
-    was available that reads its data from a text file in the CABO Weather format.
-    Nevertheless, building CABO weather files is tedious as for each year a new
-    file must constructed. Moreover it is rather error prone and formatting
-    mistakes are easily leading to errors.
+    was available, which reads its data from a text file in the CABO Weather format.
+    However, building CABO weather files is tedious, as a new file must be
+    constructed for each year. Moreover, it is rather error-prone and formatting
+    mistakes easily lead to errors.
 
     To simplify providing weather data to PCSE models, a new data provider
-    was written that reads its data from simple excel files
+    was written that reads its data from simple Excel files.
 
     The ExcelWeatherDataProvider assumes that records are complete and does
     not make an effort to interpolate data as this can be easily
@@ -86,7 +86,7 @@ class ExcelWeatherDataProvider(WeatherDataProvider):
     }
 
     # row numbers where values start. Note that the row numbers are
-    # zero-based, so add 1 to find the corresponding row in excel.
+    # zero-based, so add 1 to find the corresponding row in Excel.
     site_row = 9
     label_row = 11
     data_start_row = 13
@@ -158,7 +158,7 @@ class ExcelWeatherDataProvider(WeatherDataProvider):
                             d[label] = cell.value.date()
                             continue
 
-                    # explicitly convert to float. If this fails a ValueError will be thrown
+                    # Explicitly convert to float. If this fails a ValueError will be thrown
                     value = float(cell.value)
 
                     # Check for observations marked as missing. Currently only missing
@@ -185,7 +185,7 @@ class ExcelWeatherDataProvider(WeatherDataProvider):
                 # Reference ET in mm/day
                 e0, es0, et0 = reference_ET(LAT=self.latitude, ELEV=self.elevation, ANGSTA=self.angstA,
                                             ANGSTB=self.angstB, **d)
-                # convert to cm/day
+                # Convert to cm/day
                 d["E0"] = e0/10.; d["ES0"] = es0/10.; d["ET0"] = et0/10.
 
                 wdc = WeatherDataContainer(LAT=self.latitude, LON=self.longitude, ELEV=self.elevation, **d)
@@ -209,7 +209,7 @@ class ExcelWeatherDataProvider(WeatherDataProvider):
                  return False
 
     def _find_cache_file(self, xls_fname):
-        """Try to find a cache file for file name
+        """Try to find a cache file for file name.
 
         Returns None if the cache file does not exist, else it returns the full path
         to the cache file.
@@ -224,7 +224,7 @@ class ExcelWeatherDataProvider(WeatherDataProvider):
         return None
 
     def _get_cache_filename(self, xls_fname):
-        """Constructs the filename used for cache files given xls_fname
+        """Constructs the filename used for cache files given xls_fname.
         """
         basename = os.path.basename(xls_fname)
         filename, ext = os.path.splitext(basename)
@@ -243,7 +243,7 @@ class ExcelWeatherDataProvider(WeatherDataProvider):
             self.logger.warning(msg)
 
     def _is_missing_value(self, value):
-        """Checks if value is equal to the value specified for missign date
+        """Checks if value is equal to the value specified for missign date.
 
         :return: True|False
         """

--- a/pcse/fileinput/excelweatherdataprovider.py
+++ b/pcse/fileinput/excelweatherdataprovider.py
@@ -218,7 +218,7 @@ class ExcelWeatherDataProvider(WeatherDataProvider):
         if os.path.exists(cache_filename):
             cache_date = os.stat(cache_filename).st_mtime
             xls_date = os.stat(xls_fname).st_mtime
-            if cache_date > xls_date:  # cache is more recent then XLS file
+            if cache_date > xls_date:  # cache is more recent than XLS file
                 return cache_filename
 
         return None

--- a/pcse/fileinput/pcsefilereader.py
+++ b/pcse/fileinput/pcsefilereader.py
@@ -7,13 +7,13 @@ import textwrap
 
 class PCSEFileReader(dict):
     """Reader for parameter files in the PCSE format.
-    
+
     This class is a replacement for the `CABOFileReader`. The latter can be
     used for reading parameter files in the CABO format, however this format
     has rather severe limitations: it only supports string, integer, float
     and array parameters. There is no support for specifying parameters with
     dates for example (other then specifying them as a string).
-    
+
     The `PCSEFileReader` is a much more versatile tool for creating parameter
     files because it leverages the power of the python interpreter for
     processing parameter files through the `execfile` functionality in python.
@@ -24,22 +24,22 @@ class PCSEFileReader(dict):
     :returns: dictionary object with parameter key/value pairs.
 
     *Example*
-    
+
     Below is an example of a parameter file 'parfile.pcse'. Parameters can
     be defined the 'CABO'-way, but also advanced functionality can be used by
     importing modules, defining parameters as dates or numpy arrays and even
     applying function on arrays (in this case `np.sin`)::
 
         \"\"\"This is the header of my parameter file.
-        
+
         This file is derived from the following sources
         * dummy file for demonstrating the PCSEFileReader
         * contains examples how to leverage dates, arrays and functions, etc.
         \"\"\"
-        
+
         import numpy as np
         import datetime as dt
-        
+
         TSUM1 = 1100
         TSUM2 = 900
         DTSMTB = [ 0., 0.,
@@ -51,16 +51,16 @@ class PCSEFileReader(dict):
         CROP_START_DATE = dt.date(2010,5,14)
 
     Can be read with the following statements::
-    
+
         >>>fileparameters = PCSEFileReader('parfile.pcse')
-        >>>print fileparameters['TSUM1']
+        >>>print(fileparameters['TSUM1'])
         1100
-        >>>print fileparameters['CROP_START_DATE']
+        >>>print(fileparameters['CROP_START_DATE'])
         2010-05-14
-        >>>print fileparameters
+        >>>print(fileparameters)
         PCSE parameter file contents loaded from:
         D:\\UserData\\pcse_examples\\parfile.pw
-        
+
         This is the header of my parameter file.
 
         This file is derived from the following sources
@@ -75,10 +75,10 @@ class PCSEFileReader(dict):
           -0.54402111 -0.99999021] (<type 'numpy.ndarray'>)
         TSUM1: 1100 (<type 'int'>)
     """
-    
+
     def __init__(self, fname):
         dict.__init__(self)
-        
+
         # Construct full path to parameter file and check file existence
         cwd = os.getcwd()
         self.fname_fp = os.path.normpath(os.path.join(cwd, fname))
@@ -89,13 +89,13 @@ class PCSEFileReader(dict):
         # compile and execute the contents of the file
         bytecode = compile(open(self.fname_fp).read(), self.fname_fp, 'exec')
         exec(bytecode, {}, self)
-        
+
         # Remove any members in self that are python modules
         keys = list(self.keys())
         for k in keys:
             if inspect.ismodule(self[k]):
                 self.pop(k)
-        
+
         # If the file has a header (e.g. __doc__) store it.
         if "__doc__" in self:
             header = self.pop("__doc__")

--- a/pcse/fileinput/pcsefilereader.py
+++ b/pcse/fileinput/pcsefilereader.py
@@ -12,15 +12,15 @@ class PCSEFileReader(dict):
     used for reading parameter files in the CABO format, however this format
     has rather severe limitations: it only supports string, integer, float
     and array parameters. There is no support for specifying parameters with
-    dates for example (other then specifying them as a string).
+    dates for example (other than specifying them as a string).
 
     The `PCSEFileReader` is a much more versatile tool for creating parameter
-    files because it leverages the power of the python interpreter for
-    processing parameter files through the `execfile` functionality in python.
-    This means that anything that can be done in a python script can also be
+    files because it leverages the power of the Python interpreter for
+    processing parameter files through the `execfile` functionality in Python.
+    This means that anything that can be done in a Python script can also be
     done in a PCSE parameter file.
 
-    :param fname: parameter file to read and parse
+    :param fname: parameter file to read and parse.
     :returns: dictionary object with parameter key/value pairs.
 
     *Example*
@@ -86,7 +86,7 @@ class PCSEFileReader(dict):
             msg = "Could not find parameter file '%s'" % self.fname_fp
             raise RuntimeError(msg)
 
-        # compile and execute the contents of the file
+        # Compile and execute the contents of the file
         bytecode = compile(open(self.fname_fp).read(), self.fname_fp, 'exec')
         exec(bytecode, {}, self)
 

--- a/pcse/fileinput/yaml_agro_loader.py
+++ b/pcse/fileinput/yaml_agro_loader.py
@@ -6,7 +6,7 @@ from .. import exceptions as exc
 class YAMLAgroManagementReader(list):
     """Reads PCSE agromanagement files in the YAML format.
 
-    :param fname: filename of the agromanagement file. If fname is not provided as a absolute or
+    :param fname: filename of the agromanagement file. If fname is not provided as an absolute or
         relative path the file is assumed to be in the current working directory.
     """
 

--- a/pcse/fileinput/yaml_cropdataprovider.py
+++ b/pcse/fileinput/yaml_cropdataprovider.py
@@ -175,9 +175,9 @@ class YAMLCropDataProvider(MultiCropDataProvider):
                 if fpath is not None:
                     yaml_file_names = self._get_yaml_files(fpath)
                     yaml_file_dates = [os.stat(fn).st_mtime for crop,fn in yaml_file_names.items()]
-                    # retrieve modification date of cache file
+                    # Retrieve modification date of cache file
                     cache_date = os.stat(cache_fname_fp).st_mtime
-                    # Ensure cache file is more recent then any of the YAML files
+                    # Ensure cache file is more recent than any of the YAML files
                     if any([d > cache_date for d in yaml_file_dates]):
                         return False
 

--- a/pcse/fileinput/yaml_cropdataprovider.py
+++ b/pcse/fileinput/yaml_cropdataprovider.py
@@ -39,16 +39,16 @@ class YAMLCropDataProvider(MultiCropDataProvider):
     can switch the active crop.
 
     The most basic use is to call YAMLCropDataProvider with no parameters. It will
-    than pull the crop parameters from my github repository at
+    then pull the crop parameters from my GitHub repository at
     https://github.com/ajwdewit/WOFOST_crop_parameters::
 
         >>> from pcse.fileinput import YAMLCropDataProvider
         >>> p = YAMLCropDataProvider()
         >>> print(p)
-        YAMLCropDataProvider - crop and variety not set: no activate crop parameter set!
+        YAMLCropDataProvider - crop and variety not set: no active crop parameter set!
 
-    All crops and varieties have been loaded from the YAML file, however no activate
-    crop has been set. Therefore, we need to activate a a particular crop and variety:
+    All crops and varieties have been loaded from the YAML file, however no active
+    crop has been set. Therefore, we need to activate a particular crop and variety:
 
         >>> p.set_active_crop('wheat', 'Winter_wheat_101')
         >>> print(p)
@@ -64,9 +64,9 @@ class YAMLCropDataProvider(MultiCropDataProvider):
 
         >>> p = YAMLCropDataProvider(fpath=r"D:\\UserData\\sources\\WOFOST_crop_parameters")
         >>> print(p)
-        YAMLCropDataProvider - crop and variety not set: no activate crop parameter set!
+        YAMLCropDataProvider - crop and variety not set: no active crop parameter set!
 
-    Finally, it is possible to pull data from your fork of my github repository by specifying
+    Finally, it is possible to pull data from your fork of my GitHub repository by specifying
     the URL to that repository::
 
         >>> p = YAMLCropDataProvider(repository=\"https://raw.githubusercontent.com/<your_account>/WOFOST_crop_parameters/master/\")
@@ -112,9 +112,9 @@ class YAMLCropDataProvider(MultiCropDataProvider):
                 pickle.dump((self.compatible_version, self._store), fp, pickle.HIGHEST_PROTOCOL)
 
     def read_local_repository(self, fpath):
-        """Reads the crop YAML files on the local file system
+        """Reads the crop YAML files on the local file system.
 
-        :param fpath: the location of the YAML files on the filesystem
+        :param fpath: the location of the YAML files on the filesystem.
         """
         yaml_file_names = self._get_yaml_files(fpath)
         for crop_name, yaml_fname in yaml_file_names.items():
@@ -124,10 +124,10 @@ class YAMLCropDataProvider(MultiCropDataProvider):
             self._add_crop(crop_name, parameters)
 
     def read_remote_repository(self, repository):
-        """Reads the crop files from a remote git repository
+        """Reads the crop files from a remote git repository.
 
         :param repository: The url of the repository pointing to the URL where the raw inputs can be obtained.
-            E.g. for github this is https://raw.githubusercontent.com/ajwdewit/WOFOST_crop_parameters/master
+            E.g. for GitHub this is https://raw.githubusercontent.com/ajwdewit/WOFOST_crop_parameters/master
         :return:
         """
 
@@ -171,7 +171,7 @@ class YAMLCropDataProvider(MultiCropDataProvider):
             if os.path.exists(cache_fname_fp):
 
                 # First we check that the cache file reflects the contents of the YAML files.
-                # This only works for files not for github repos
+                # This only works for files not for GitHub repos
                 if fpath is not None:
                     yaml_file_names = self._get_yaml_files(fpath)
                     yaml_file_dates = [os.stat(fn).st_mtime for crop,fn in yaml_file_names.items()]
@@ -201,7 +201,7 @@ class YAMLCropDataProvider(MultiCropDataProvider):
 
         Raises an exception if the parameter set is incompatible.
 
-        :param parameters: The parameter set loaded by YAML
+        :param parameters: The parameter set loaded by YAML.
         """
         try:
             v = parameters['Version']
@@ -219,7 +219,7 @@ class YAMLCropDataProvider(MultiCropDataProvider):
         self._store[crop_name] = variety_sets
 
     def _get_yaml_files(self, fpath):
-        """Returns all the files ending on *.yaml in the given path.
+        """Returns all the files ending with *.yaml in the given path.
         """
         fname = os.path.join(fpath, "crops.yaml")
         if not os.path.exists(fname):
@@ -234,12 +234,12 @@ class YAMLCropDataProvider(MultiCropDataProvider):
         return crop_yaml_fnames
 
     def set_active_crop(self, crop_name, variety_name):
-        """Sets the parameters in the internal dict for given crop_name and variety_name
+        """Sets the parameters in the internal dict for given crop_name and variety_name.
 
-        It first clears the active set of crop parameter sin the internal dict.
+        It first clears the active set of crop parameters in the internal dict.
 
-        :param crop_name: the name of the crop
-        :param variety_name: the variety for the given crop
+        :param crop_name: the name of the crop.
+        :param variety_name: the variety for the given crop.
         """
         self.clear()
         if crop_name not in self._store:
@@ -256,7 +256,7 @@ class YAMLCropDataProvider(MultiCropDataProvider):
 
         # Retrieve parameter name/values from input (ignore description and units)
         parameters = {k: v[0] for k, v in variety_sets[variety_name].items() if k != "Metadata"}
-        # update internal dict with parameter values for this variety
+        # Update internal dict with parameter values for this variety
         self.update(parameters)
 
     def get_crops_varieties(self):

--- a/pcse/settings/default_settings.py
+++ b/pcse/settings/default_settings.py
@@ -13,7 +13,7 @@ from pcse.settings.settings
 For example, to use the settings in a module under 'crop':
 
     from ..settings import settings
-    print settings.METEO_CACHE_DIR
+    print(settings.METEO_CACHE_DIR)
 
 Settings that are not ALL-CAPS will generate a warning. To avoid warnings
 for everything that is not a setting (such as imported modules), prepend

--- a/pcse/settings/default_settings.py
+++ b/pcse/settings/default_settings.py
@@ -17,13 +17,13 @@ For example, to use the settings in a module under 'crop':
 
 Settings that are not ALL-CAPS will generate a warning. To avoid warnings
 for everything that is not a setting (such as imported modules), prepend
-and underscore to the name.
+an underscore to the name.
 """
 
 import os as _os
 from .. import util as _util
 
-PCSE_USER_HOME =  _os.path.join(_util.get_user_home(), ".pcse")
+PCSE_USER_HOME = _os.path.join(_util.get_user_home(), ".pcse")
 
 # Location for meteo cache files
 METEO_CACHE_DIR = _os.path.join(PCSE_USER_HOME, "meteo_cache")
@@ -65,24 +65,24 @@ LOG_CONFIG = \
                 },
                 'handlers': {
                     'console': {
-                        'level':LOG_LEVEL_CONSOLE,
-                        'class':'logging.StreamHandler',
-                        'formatter':'brief'
+                        'level': LOG_LEVEL_CONSOLE,
+                        'class': 'logging.StreamHandler',
+                        'formatter': 'brief'
                     },
                     'file': {
-                        'level':LOG_LEVEL_FILE,
-                        'class':'logging.handlers.RotatingFileHandler',
-                        'formatter':'standard',
-                        'filename':LOG_FILE_NAME,
+                        'level': LOG_LEVEL_FILE,
+                        'class': 'logging.handlers.RotatingFileHandler',
+                        'formatter': 'standard',
+                        'filename': LOG_FILE_NAME,
                         'maxBytes': 1024**2,
                         'backupCount': 7,
-                        'mode':'a',
+                        'mode': 'a',
                         'encoding': 'utf8'
                     },
                 },
                 'root': {
                          'handlers': ['console', 'file'],
                          'propagate': True,
-                         'level':'NOTSET'
+                         'level': 'NOTSET'
                 }
             }

--- a/pcse/signals.py
+++ b/pcse/signals.py
@@ -20,48 +20,48 @@ documentation of the PyDispatcher_ package for more information::
     import math
     sys.path.append('/home/wit015/Sources/python/pcse/')
     import datetime as dt
-    
+
     import pcse
     from pcse.base import SimulationObject, VariableKiosk
-    
+
     mysignal = "My first signal"
-    
+
     class MySimObj(SimulationObject):
-        
+
         def initialize(self, day, kiosk):
             self._connect_signal(self.handle_mysignal, mysignal)
-    
+
         def handle_mysignal(self, arg1, arg2):
-            print "Value of arg1,2: %s, %s" % (arg1, arg2)
-    
+            print("Value of arg1,2: %s, %s" % (arg1, arg2))
+
         def send_signal_with_exact_arguments(self):
             self._send_signal(signal=mysignal, arg2=math.pi, arg1=None)
-    
+
         def send_signal_with_more_arguments(self):
-            self._send_signal(signal=mysignal, arg2=math.pi, arg1=None, 
+            self._send_signal(signal=mysignal, arg2=math.pi, arg1=None,
                               extra_arg="extra")
-    
+
         def send_signal_with_missing_arguments(self):
             self._send_signal(signal=mysignal, arg2=math.pi, extra_arg="extra")
-    
-            
+
+
     # Create an instance of MySimObj
     day = dt.date(2000,1,1)
     k = VariableKiosk()
     mysimobj = MySimObj(day, k)
-    
+
     # This sends exactly the right amount of keyword arguments
     mysimobj.send_signal_with_exact_arguments()
-    
+
     # this sends an additional keyword argument 'extra_arg' which is ignored.
     mysimobj.send_signal_with_more_arguments()
-    
+
     # this sends the signal with a missing 'arg1' keyword argument which the handler
     # expects and thus causes an error, raising a TypeError
     try:
         mysimobj.send_signal_with_missing_arguments()
     except TypeError, exc:
-        print "TypeError occurred: %s" % exc
+        print("TypeError occurred: %s" % exc)
 
 Saving this code as a file `test_signals.py` and importing it gives the
 following output::
@@ -77,13 +77,13 @@ keywords.
 **CROP_START**
 
  Indicates that a new crop cycle will start:
- 
+
      self._send_signal(signal=signals.crop_start, day=<date>,
                        crop_name=<string>, variety_name=<string>,
                        crop_start_type=<string>, crop_end_type=<string>)
 
  keyword arguments with `signals.crop_start`:
-    
+
     * day: Current date
     * crop_name: a string identifying the crop
     * variety_name: a string identifying the crop variety
@@ -93,7 +93,7 @@ keywords.
 **CROP_FINISH**
 
  Indicates that the current crop cycle is finished::
- 
+
      self._send_signal(signal=signals.crop_finish, day=<date>,
                        finish_type=<string>, crop_delete=<True|False>)
 
@@ -107,7 +107,7 @@ keyword arguments with `signals.crop_finish`:
       Defaults to False.
 
 **TERMINATE**
- 
+
  Indicates that the entire system should terminate (crop & soil water balance) and
  that terminal output should be collected::
 
@@ -120,7 +120,7 @@ keyword arguments with `signals.crop_finish`:
  Indicates that the model state should be saved for later use::
 
     self._send_signal(signal=signals.output)
- 
+
  No keyword arguments are defined for this signal
 
 **SUMMARY_OUTPUT**
@@ -181,5 +181,5 @@ output = "OUTPUT"
 summary_output = "SUMMARY_OUTPUT"
 apply_npk = "APPLY_NPK"
 apply_n = "APPLY_N"
-irrigate = "IRRIGATE" 
+irrigate = "IRRIGATE"
 mowing = "MOWING"

--- a/pcse/tests/test_wofost72.py
+++ b/pcse/tests/test_wofost72.py
@@ -28,11 +28,11 @@ from ..settings import settings
 
 class WofostBenchmarkRetriever:
     """Retrieves benchmark results for PCSE WOFOST.
-    
+
     Class retrieves benchmarks from the PCSE DB that are being used to
     unittest (benchmark) the WOFOST output. The benchmarks are stored in the
     table 'wofost_unittest_benchmarks'.
-    
+
     Example:
     retriever = WofostBenchmarkRetriever('data source name', crop, grid, mode)
     benchmark_data = retriever('development_stage')
@@ -47,7 +47,7 @@ class WofostBenchmarkRetriever:
         self.grid = grid
         self.mode = mode
         self.member_id = 0
-    
+
     def __call__(self, variable):
         "Retrieves benchmark data for specified variable: [(day, variable),..]"
         t1 = self.table_benchm.alias()
@@ -66,16 +66,16 @@ class WofostBenchmarkRetriever:
 
 class WofostOutputRetriever:
     """Retrieves results from a Wofost simulation.
-    
+
     Class retrieves results from a Wofost simulation based on the table
     'sim_results_timeseries'. These results are then compared to the benchmark
     results for unit testing. This procedure assumes that there is only a single
     simulation (grid, crop, year) present in the table 'sim_results_timeseries'
     as no selection on (grid, crop, year) is being done.
-    
+
     Example:
     retriever = WofostOutputRetriever('data source name')
-    
+
     one_day = retriever(date(2000,1,1), 'development_stage')
     last_day = retriever.getWofostOutputLastDay('development_stage')
     """
@@ -87,14 +87,14 @@ class WofostOutputRetriever:
                                autoload=True)
         s = select([func.max(self.table_pwo.c.day, type_=saDate)])
         self.maxday = s.execute().fetchone()[0]
-    
+
     def __call__(self, day, variable):
         """Returns the specified WOFOST variable for specified day."""
         s = select([self.table_pwo], and_(self.table_pwo.c.day==day))
         row = s.execute().fetchone()
-        #print "day %s" % day
+        #print("day %s" % day)
         return row[variable]
-        
+
     def getWofostOutputLastDay(self, variable):
         """Returns the specified WOFOST variable on the last day."""
         s = select([self.table_pwo], and_(self.table_pwo.c.day==self.maxday))
@@ -104,16 +104,16 @@ class WofostOutputRetriever:
 
 class WofostTestingTemplate(unittest.TestCase):
     """Template for executing WOFOST unit tests.
-    
+
     The template defines the setUp() and runTest() routines that are common to
     all WOFOST unit testing runs. Most of functionality comes from
     subclassing 'unittest.TestCase'. Note that each unittest is simply defined
     as a subclass of this template. Only the crop, grid, year and mode are
     test-specific and thus defined as test class attributes.
-    
+
     To prevent false FAILS caused by different python versions, databases and
     cpu architectures, biomass values are only checked for accuracy up to one
-    or three decimals.    
+    or three decimals.
     """
 
     benchmark_vars = [("DVS",3), ("TRA",3), ("RD",3),("SM", 3), ("LAI",2),
@@ -126,7 +126,7 @@ class WofostTestingTemplate(unittest.TestCase):
             dsn = "sqlite:///" + db_location
         self.dsn = dsn
         unittest.TestCase.__init__(self, testname)
-        
+
     def setUp(self):
         "Sets up the simulation in order to verify the results"
         run_wofost(dsn=self.dsn, crop=self.crop, year=self.year,
@@ -176,7 +176,7 @@ class TestPotentialWinterWheat(WofostTestingTemplate):
     year = 2000
     grid = 31031
     mode = "pp"
-        
+
 
 class TestWaterlimitedWinterWheat(WofostTestingTemplate):
     crop = 1
@@ -218,7 +218,7 @@ class TestPotentialPotato(WofostTestingTemplate):
     year = 2000
     grid = 31031
     mode = "pp"
-        
+
 
 class TestWaterlimitedPotato(WofostTestingTemplate):
     crop = 7
@@ -246,7 +246,7 @@ class TestPotentialSunflower(WofostTestingTemplate):
     year = 2000
     grid = 31031
     mode = "pp"
-        
+
 
 class TestWaterlimitedSunflower(WofostTestingTemplate):
     crop = 11
@@ -257,7 +257,7 @@ class TestWaterlimitedSunflower(WofostTestingTemplate):
 
 def suite(dsn=None):
     """returns the unit tests for the PCSE/WOFOST model.
-    
+
     keyword parameters:
     dsn : SQLAlchemy data source name for the database that should be used.
     """

--- a/pcse/util.py
+++ b/pcse/util.py
@@ -930,7 +930,7 @@ class DummySoilDataProvider(dict):
 def version_tuple(v):
     """Creates a version tuple from a version string for consistent comparison of versions.
 
-    Conversion to tuples is needed because version '2.12.9' is higher then '2.7.8' however::
+    Conversion to tuples is needed because version '2.12.9' is higher than '2.7.8' however::
 
     >>> '2.12.9' > '2.7.8'
     False

--- a/pcse/util.py
+++ b/pcse/util.py
@@ -120,7 +120,7 @@ def reference_ET(DAY, LAT, ELEV, TMIN, TMAX, IRRAD, VAP, WIND,
 
 def penman(DAY, LAT, ELEV, TMIN, TMAX, AVRAD, VAP, WIND2, ANGSTA, ANGSTB):
     """Calculates E0, ES0, ET0 based on the Penman model.
-    
+
      This routine calculates the potential evapo(transpi)ration rates from
      a free water surface (E0), a bare soil surface (ES0), and a crop canopy
      (ET0) in mm/d. For these calculations the analysis by Penman is followed
@@ -128,20 +128,20 @@ def penman(DAY, LAT, ELEV, TMIN, TMAX, AVRAD, VAP, WIND2, ANGSTA, ANGSTB):
      Subroutines and functions called: ASTRO, LIMIT.
 
     Input variables::
-    
+
         DAY     -  Python datetime.date object                                    -
-        LAT     -  Latitude of the site                        degrees   
-        ELEV    -  Elevation above sea level                      m      
+        LAT     -  Latitude of the site                        degrees
+        ELEV    -  Elevation above sea level                      m
         TMIN    -  Minimum temperature                            C
-        TMAX    -  Maximum temperature                            C      
-        AVRAD   -  Daily shortwave radiation                   J m-2 d-1 
+        TMAX    -  Maximum temperature                            C
+        AVRAD   -  Daily shortwave radiation                   J m-2 d-1
         VAP     -  24-hour average vapour pressure               hPa
         WIND2   -  24-hour average windspeed at 2 meter          m/s
         ANGSTA  -  Empirical constant in Angstrom formula         -
         ANGSTB  -  Empirical constant in Angstrom formula         -
 
     Output is a tuple (E0,ES0,ET0)::
-    
+
         E0      -  Penman potential evaporation from a free water surface [mm/d]
         ES0     -  Penman potential evaporation from a moist bare soil surface [mm/d]
         ET0     -  Penman potential transpiration from a crop canopy [mm/d]
@@ -167,7 +167,7 @@ def penman(DAY, LAT, ELEV, TMIN, TMAX, AVRAD, VAP, WIND2, ANGSTA, ANGSTB):
     GAMMA = PSYCON*PBAR/1013.
 
     # saturated vapour pressure according to equation of Goudriaan
-    # (1977) derivative of SVAP with respect to temperature, i.e. 
+    # (1977) derivative of SVAP with respect to temperature, i.e.
     # slope of the SVAP-temperature curve (mbar/Celsius);
     # measured vapour pressure not to exceed saturated vapour pressure
 
@@ -199,14 +199,14 @@ def penman(DAY, LAT, ELEV, TMIN, TMAX, AVRAD, VAP, WIND2, ANGSTA, ANGSTB):
 
     # Penman formula (1948)
     E0  = (DELTA*RNW+GAMMA*EA)/(DELTA+GAMMA)
-    ES0 = (DELTA*RNS+GAMMA*EA)/(DELTA+GAMMA) 
+    ES0 = (DELTA*RNS+GAMMA*EA)/(DELTA+GAMMA)
     ET0 = (DELTA*RNC+GAMMA*EAC)/(DELTA+GAMMA)
 
     # Ensure reference evaporation >= 0.
     E0  = max(0., E0)
     ES0 = max(0., ES0)
     ET0 = max(0., ET0)
-    
+
     return E0, ES0, ET0
 
 
@@ -309,7 +309,7 @@ def penman_monteith(DAY, LAT, ELEV, TMIN, TMAX, AVRAD, VAP, WIND2):
 
 def check_angstromAB(xA, xB):
     """Routine checks validity of Angstrom coefficients.
-    
+
     This is the  python version of the FORTRAN routine 'WSCAB' in 'weather.for'.
     """
     MIN_A = 0.1
@@ -388,22 +388,22 @@ def vap_from_relhum(rh, temp):
 
 def angstrom(day, latitude, ssd, cA, cB):
     """Compute global radiation using the Angstrom equation.
-    
+
     Global radiation is derived from sunshine duration using the Angstrom
     equation:
     globrad = Angot * (cA + cB * (sunshine / daylength)
-    
+
     :param day: day of observation (date object)
     :param latitude: Latitude of the observation
     :param ssd: Observed sunshine duration
     :param cA: Angstrom A parameter
-    :param cB: Angstrom B parameter    
+    :param cB: Angstrom B parameter
     :returns: the global radiation in J/m2/day
     """
     r = astro(day, latitude, 0)
     globrad = r.ANGOT * (cA + cB * (ssd / r.DAYL))
     return globrad
-                       
+
 
 def doy(day):
     """Converts a date or datetime object to day-of-year (Jan 1st = doy 1)
@@ -422,7 +422,7 @@ def limit(vmin, vmax, v):
 
     if vmin > vmax:
         raise RuntimeError("Min value (%f) larger than max (%f)" % (vmin, vmax))
-    
+
     if v < vmin:       # V below range: return min
         return vmin
     elif v < vmax:     # v within range: return v
@@ -438,7 +438,7 @@ def daylength(day, latitude, angle=-4, _cache={}):
     :param latitude:    latitude of location
     :param angle:       The photoperiodic daylength starts/ends when the sun
         is `angle` degrees under the horizon. Default is -4 degrees.
-    
+
     Derived from the WOFOST routine ASTRO.FOR and simplified to include only
     daylength calculation. Results are being cached for performance
     """
@@ -448,10 +448,10 @@ def daylength(day, latitude, angle=-4, _cache={}):
     if abs(latitude) > 90.:
         msg = "Latitude not between -90 and 90"
         raise RuntimeError(msg)
-    
+
     # Calculate day-of-year from date object day
     IDAY = doy(day)
-    
+
     # Test if daylength for given (day, latitude, angle) was already calculated
     # in a previous run. If not (e.g. KeyError) calculate the daylength, store
     # in cache and return the value.
@@ -459,7 +459,7 @@ def daylength(day, latitude, angle=-4, _cache={}):
         return _cache[(IDAY, latitude, angle)]
     except KeyError:
         pass
-    
+
     # constants
     RAD = radians(1.)
 
@@ -481,13 +481,13 @@ def daylength(day, latitude, angle=-4, _cache={}):
 
     # store results in cache
     _cache[(IDAY, latitude, angle)] = DAYLP
-    
+
     return DAYLP
 
 
 def astro(day, latitude, radiation, _cache={}):
     """python version of ASTRO routine by Daniel van Kraalingen.
-    
+
     This subroutine calculates astronomic daylength, diurnal radiation
     characteristics such as the atmospheric transmission, diffuse radiation etc.
 
@@ -497,19 +497,19 @@ def astro(day, latitude, radiation, _cache={}):
 
     output is a `namedtuple` in the following order and tags::
 
-        DAYL      Astronomical daylength (base = 0 degrees)     h      
-        DAYLP     Astronomical daylength (base =-4 degrees)     h      
-        SINLD     Seasonal offset of sine of solar height       -      
-        COSLD     Amplitude of sine of solar height             -      
+        DAYL      Astronomical daylength (base = 0 degrees)     h
+        DAYLP     Astronomical daylength (base =-4 degrees)     h
+        SINLD     Seasonal offset of sine of solar height       -
+        COSLD     Amplitude of sine of solar height             -
         DIFPP     Diffuse irradiation perpendicular to
-                  direction of light                         J m-2 s-1 
-        ATMTR     Daily atmospheric transmission                -      
+                  direction of light                         J m-2 s-1
+        ATMTR     Daily atmospheric transmission                -
         DSINBE    Daily total of effective solar height         s
         ANGOT     Angot radiation at top of atmosphere       J m-2 d-1
- 
+
     Authors: Daniel van Kraalingen
     Date   : April 1991
- 
+
     Python version
     Author      : Allard de Wit
     Date        : January 2011
@@ -520,10 +520,10 @@ def astro(day, latitude, radiation, _cache={}):
         msg = "Latitude not between -90 and 90"
         raise RuntimeError(msg)
     LAT = latitude
-        
+
     # Determine day-of-year (IDAY) from day
     IDAY = doy(day)
-    
+
     # reassign radiation
     AVRAD = radiation
 
@@ -550,7 +550,7 @@ def astro(day, latitude, radiation, _cache={}):
     AOB = SINLD/COSLD
 
     # For very high latitudes and days in summer and winter a limit is
-    # inserted to avoid math errors when daylength reaches 24 hours in 
+    # inserted to avoid math errors when daylength reaches 24 hours in
     # summer or 0 hours in winter.
 
     # Calculate solution for base=0 degrees
@@ -563,7 +563,7 @@ def astro(day, latitude, radiation, _cache={}):
     else:
         if AOB >  1.0: DAYL = 24.0
         if AOB < -1.0: DAYL = 0.0
-        # integrals of sine of solar height	
+        # integrals of sine of solar height
         DSINB = 3600.*(DAYL*SINLD)
         DSINBE = 3600.*(DAYL*(SINLD+0.4*(SINLD**2+COSLD**2*0.5)))
 
@@ -604,15 +604,15 @@ def astro(day, latitude, radiation, _cache={}):
 
 class Afgen(object):
     """Emulates the AFGEN function in WOFOST.
-    
+
     :param tbl_xy: List or array of XY value pairs describing the function
         the X values should be mononically increasing.
 
-    Returns the interpolated value provided with the 
+    Returns the interpolated value provided with the
     absicca value at which the interpolation should take place.
-    
+
     example::
-    
+
         >>> tbl_xy = [0,0,1,1,5,10]
         >>> f =  Afgen(tbl_xy)
         >>> f(0.5)
@@ -626,21 +626,21 @@ class Afgen(object):
         >>> f(-1)
         0.0
     """
-    
+
     def _check_x_ascending(self, tbl_xy):
         """Checks that the x values are strictly ascending.
-        
+
         Also truncates any trailing (0.,0.) pairs as a results of data coming
         from a CGMS database.
         """
         x_list = tbl_xy[0::2]
         y_list = tbl_xy[1::2]
         n = len(x_list)
-        
+
         # Check if x range is ascending continuously
         rng = list(range(1, n))
         x_asc = [True if (x_list[i] > x_list[i-1]) else False for i in rng]
-        
+
         # Check for breaks in the series where the ascending sequence stops.
         # Only 0 or 1 breaks are allowed. Use the XOR operator '^' here
         sum_break = sum([1 if (x0 ^ x1) else 0 for x0,x1 in zip(x_asc, x_asc[1:])])
@@ -658,11 +658,11 @@ class Afgen(object):
             msg = ("X values for AFGEN input list not strictly ascending: %s"
                    % x_list)
             raise ValueError(msg)
-        
-        return x, y            
+
+        return x, y
 
     def __init__(self, tbl_xy):
-        
+
         x_list, y_list = self._check_x_ascending(tbl_xy)
         x_list = self.x_list = list(map(float, x_list))
         y_list = self.y_list = list(map(float, y_list))
@@ -697,15 +697,15 @@ class AfgenTrait(TraitType):
 
 def merge_dict(d1, d2, overwrite=False):
     """Merge contents of d1 and d2 and return the merged dictionary
-    
+
     Note:
-    
+
     * The dictionaries d1 and d2 are unaltered.
     * If `overwrite=False` (default), a `RuntimeError` will be raised when
       duplicate keys exist, else any existing keys in d1 are silently
-      overwritten by d2.  
+      overwritten by d2.
     """
-    # Note: May  partially be replaced by a ChainMap as of python 3.3 
+    # Note: May  partially be replaced by a ChainMap as of python 3.3
     if overwrite is False:
         sd1 = set(d1.keys())
         sd2 = set(d2.keys())
@@ -910,8 +910,8 @@ class DummySoilDataProvider(dict):
     """This class is to provide some dummy soil parameters for potential production simulation.
 
     Simulation of potential production levels is independent of the soil. Nevertheless, the model
-    does not some parameter values. This data provider provides some hard coded parameter values for
-    this situation.
+    does not some provide parameter values. This data provider provides some hard coded parameter
+    values for this situation.
     """
     _defaults = {"SMFCF":0.3,
                  "SM0":0.4,
@@ -1003,7 +1003,7 @@ class WOFOST72SiteDataProvider(_GenericSiteDataProvider):
 
     Currently only the value for WAV is mandatory to specify.
     """
-    
+
     _defaults = {"IFUNRN": (0, {0, 1}, int),
                  "NOTINF": (0, [0., 1.], float),
                  "SSI": (0., [0., 100.], float),


### PR DESCRIPTION
Some very minor textual fixes I made while reading through the documentation.

- Fixed typos, capitalisation, punctuation in docs.
- Fixed typos, capitalisation, punctuation in docstrings and comments.
- Fixed typos in Exception/Error messages.
- Removed a reference to a `CABOFileReader.get_header()` method that doesn't exist.
- Updated reference to new NASA Power website.
- Updated examples in documentation to Python 3's `print()` function.
- Whitespace improvements (done automatically by my IDE).