### PR TITLE
Fix copying of CABOFileReader, PCSEFileReader, DummySoilDataProvider

### DIFF
--- a/pcse/fileinput/cabo_reader.py
+++ b/pcse/fileinput/cabo_reader.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2004-2014 Alterra, Wageningen-UR
 # Allard de Wit (allard.dewit@wur.nl), April 2014
+import copy
 import re
 
 from ..exceptions import PCSEError
@@ -13,10 +14,10 @@ class LengthError(PCSEError):
 
 class DuplicateError(PCSEError):
     pass
-    
+
 class CABOFileReader(dict):
     """Reads CABO files with model parameter definitions.
-    
+
     The parameter definitions of Wageningen crop models are generally
     written in the CABO format. This class reads the contents, parses
     the parameter names/values and returns them as a dictionary.
@@ -31,28 +32,28 @@ class CABOFileReader(dict):
     The header of the CABO file (marked with ** at the first line) is
     read and can be retrieved by the get_header() method or just by
     a print on the returned dictionary.
-    
+
     *Example*
-    
+
     A parameter file 'parfile.cab' which looks like this::
-    
+
         ** CROP DATA FILE for use with WOFOST Version 5.4, June 1992
         **
         ** WHEAT, WINTER 102
-        ** Regions: Ireland, central en southern UK (R72-R79), 
+        ** Regions: Ireland, central en southern UK (R72-R79),
         **          Netherlands (not R47), northern Germany (R11-R14)
         CRPNAM='Winter wheat 102, Ireland, N-U.K., Netherlands, N-Germany'
         CROP_NO=99
         TBASEM   = -10.0    ! lower threshold temp. for emergence [cel]
-        DTSMTB   =   0.00,    0.00,     ! daily increase in temp. sum 
+        DTSMTB   =   0.00,    0.00,     ! daily increase in temp. sum
                     30.00,   30.00,     ! as function of av. temp. [cel; cel d]
                     45.00,   30.00
         ** maximum and minimum concentrations of N, P, and K
         ** in storage organs        in vegetative organs [kg kg-1]
         NMINSO   =   0.0110 ;       NMINVE   =   0.0030
-    
+
     Can be read with the following statements::
-    
+
         >>>fileparameters = CABOFileReader('parfile.cab')
         >>>print fileparameters['CROP_NO']
         99
@@ -83,7 +84,7 @@ class CABOFileReader(dict):
             if len(line)>0:
                 t.append(line)
         return t
-        
+
     def _remove_inline_comments(self, filecontents):
         t = []
         for line in filecontents:
@@ -92,7 +93,7 @@ class CABOFileReader(dict):
             if len(line) > 0:
                 t.append(line)
         return t
-    
+
     def _is_comment(self, line):
         if line.startswith("*"):
             return True
@@ -100,7 +101,7 @@ class CABOFileReader(dict):
             return False
 
     def _find_header(self, filecontents):
-        """Parses and strips header marked with '*' at the beginning of 
+        """Parses and strips header marked with '*' at the beginning of
         the file. Further lines marked with '*' are deleted."""
 
         header = []
@@ -119,7 +120,7 @@ class CABOFileReader(dict):
                 else:
                     other_contents.append(line)
         return (header, other_contents)
- 
+
     def _parse_table_values(self, parstr):
         """Parses table parameter into a list of floats."""
 
@@ -135,13 +136,13 @@ class CABOFileReader(dict):
             value = float(vstr)
             tblvalues.append(value)
         return tblvalues
-        
+
     def _find_parameter_sections(self, filecontents):
         "returns the sections defining float, string and table parameters."
         scalars = ""
         strings = ""
         tables = ""
-        
+
         for line in filecontents:
             if line.find("'") != -1: # string parameter
                 strings += (line + " ")
@@ -149,9 +150,9 @@ class CABOFileReader(dict):
                 tables += (line + " ")
             else:
                 scalars += (line + " ")
-                
+
         return scalars, strings, tables
-       
+
     def _find_individual_pardefs(self, regexp, parsections):
         """Splits the string into individual parameters definitions.
         """
@@ -164,7 +165,7 @@ class CABOFileReader(dict):
                   ("Failed to parse:\n %s" % rest)
             raise PCSEError(msg)
         return par_definitions
-        
+
     def __init__(self, fname):
         with open(fname) as fp:
             filecontents = fp.readlines()
@@ -197,7 +198,7 @@ class CABOFileReader(dict):
                     value = int(valuestr)
                 self[parname] = value
             except (ValueError) as exc:
-                msg = "Failed to parse parameter, value: %s, %s" 
+                msg = "Failed to parse parameter, value: %s, %s"
                 raise PCSEError(msg % (parstr, valuestr))
 
         for parstr in string_defs:
@@ -207,7 +208,7 @@ class CABOFileReader(dict):
                 value = (valuestr.replace("'","")).replace('"','')
                 self[parname] = value
             except (ValueError) as exc:
-                msg = "Failed to parse parameter, value: %s, %s" 
+                msg = "Failed to parse parameter, value: %s, %s"
                 raise PCSEError(msg % (parstr, valuestr))
 
         for parstr in table_defs:
@@ -222,7 +223,7 @@ class CABOFileReader(dict):
             except (LengthError) as exc:
                 msg = "Failed to parse table parameter %s: %s. \n" % (parname, valuestr)
                 msg += "Table parameter should contain at least 4 values "
-                msg += "instead got %i" 
+                msg += "instead got %i"
                 raise PCSEError(msg % exc.value[0])
             except (XYPairsError) as exc:
                 msg = "Failed to parse table parameter %s: %s\n" % (parname, valuestr)
@@ -237,3 +238,10 @@ class CABOFileReader(dict):
         for key, value in self.items():
             msg += ("%s: %s %s\n" % (key, value, type(value)))
         return msg
+
+    def copy(self):
+        """
+        Overrides the inherited dict.copy method, which returns a dict.
+        This instead preserves the class and attributes like .header.
+        """
+        return copy.copy(self)

--- a/pcse/fileinput/pcsefilereader.py
+++ b/pcse/fileinput/pcsefilereader.py
@@ -1,19 +1,20 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2004-2014 Alterra, Wageningen-UR
 # Allard de Wit (allard.dewit@wur.nl), April 2014
+import copy
 import os, sys
 import inspect
 import textwrap
 
 class PCSEFileReader(dict):
     """Reader for parameter files in the PCSE format.
-    
+
     This class is a replacement for the `CABOFileReader`. The latter can be
     used for reading parameter files in the CABO format, however this format
     has rather severe limitations: it only supports string, integer, float
     and array parameters. There is no support for specifying parameters with
     dates for example (other then specifying them as a string).
-    
+
     The `PCSEFileReader` is a much more versatile tool for creating parameter
     files because it leverages the power of the python interpreter for
     processing parameter files through the `execfile` functionality in python.
@@ -24,22 +25,22 @@ class PCSEFileReader(dict):
     :returns: dictionary object with parameter key/value pairs.
 
     *Example*
-    
+
     Below is an example of a parameter file 'parfile.pcse'. Parameters can
     be defined the 'CABO'-way, but also advanced functionality can be used by
     importing modules, defining parameters as dates or numpy arrays and even
     applying function on arrays (in this case `np.sin`)::
 
-        \"\"\"This is the header of my parameter file.
-        
+        '''This is the header of my parameter file.
+
         This file is derived from the following sources
         * dummy file for demonstrating the PCSEFileReader
         * contains examples how to leverage dates, arrays and functions, etc.
-        \"\"\"
-        
+        '''
+
         import numpy as np
         import datetime as dt
-        
+
         TSUM1 = 1100
         TSUM2 = 900
         DTSMTB = [ 0., 0.,
@@ -51,7 +52,7 @@ class PCSEFileReader(dict):
         CROP_START_DATE = dt.date(2010,5,14)
 
     Can be read with the following statements::
-    
+
         >>>fileparameters = PCSEFileReader('parfile.pcse')
         >>>print fileparameters['TSUM1']
         1100
@@ -60,7 +61,7 @@ class PCSEFileReader(dict):
         >>>print fileparameters
         PCSE parameter file contents loaded from:
         D:\\UserData\\pcse_examples\\parfile.pw
-        
+
         This is the header of my parameter file.
 
         This file is derived from the following sources
@@ -75,10 +76,10 @@ class PCSEFileReader(dict):
           -0.54402111 -0.99999021] (<type 'numpy.ndarray'>)
         TSUM1: 1100 (<type 'int'>)
     """
-    
+
     def __init__(self, fname):
         dict.__init__(self)
-        
+
         # Construct full path to parameter file and check file existence
         cwd = os.getcwd()
         self.fname_fp = os.path.normpath(os.path.join(cwd, fname))
@@ -89,13 +90,13 @@ class PCSEFileReader(dict):
         # compile and execute the contents of the file
         bytecode = compile(open(self.fname_fp).read(), self.fname_fp, 'exec')
         exec(bytecode, {}, self)
-        
+
         # Remove any members in self that are python modules
         keys = list(self.keys())
         for k in keys:
             if inspect.ismodule(self[k]):
                 self.pop(k)
-        
+
         # If the file has a header (e.g. __doc__) store it.
         if "__doc__" in self:
             header = self.pop("__doc__")
@@ -115,3 +116,10 @@ class PCSEFileReader(dict):
              r = "%s: %s (%s)" % (k, self[k], type(self[k]))
              printstr += (textwrap.fill(r, subsequent_indent="  ") + "\n")
         return printstr
+
+    def copy(self):
+        """
+        Overrides the inherited dict.copy method, which returns a dict.
+        This instead preserves the class and attributes like .header.
+        """
+        return copy.copy(self)

--- a/pcse/util.py
+++ b/pcse/util.py
@@ -120,7 +120,7 @@ def reference_ET(DAY, LAT, ELEV, TMIN, TMAX, IRRAD, VAP, WIND,
 
 def penman(DAY, LAT, ELEV, TMIN, TMAX, AVRAD, VAP, WIND2, ANGSTA, ANGSTB):
     """Calculates E0, ES0, ET0 based on the Penman model.
-    
+
      This routine calculates the potential evapo(transpi)ration rates from
      a free water surface (E0), a bare soil surface (ES0), and a crop canopy
      (ET0) in mm/d. For these calculations the analysis by Penman is followed
@@ -128,20 +128,20 @@ def penman(DAY, LAT, ELEV, TMIN, TMAX, AVRAD, VAP, WIND2, ANGSTA, ANGSTB):
      Subroutines and functions called: ASTRO, LIMIT.
 
     Input variables::
-    
+
         DAY     -  Python datetime.date object                                    -
-        LAT     -  Latitude of the site                        degrees   
-        ELEV    -  Elevation above sea level                      m      
+        LAT     -  Latitude of the site                        degrees
+        ELEV    -  Elevation above sea level                      m
         TMIN    -  Minimum temperature                            C
-        TMAX    -  Maximum temperature                            C      
-        AVRAD   -  Daily shortwave radiation                   J m-2 d-1 
+        TMAX    -  Maximum temperature                            C
+        AVRAD   -  Daily shortwave radiation                   J m-2 d-1
         VAP     -  24-hour average vapour pressure               hPa
         WIND2   -  24-hour average windspeed at 2 meter          m/s
         ANGSTA  -  Empirical constant in Angstrom formula         -
         ANGSTB  -  Empirical constant in Angstrom formula         -
 
     Output is a tuple (E0,ES0,ET0)::
-    
+
         E0      -  Penman potential evaporation from a free water surface [mm/d]
         ES0     -  Penman potential evaporation from a moist bare soil surface [mm/d]
         ET0     -  Penman potential transpiration from a crop canopy [mm/d]
@@ -167,7 +167,7 @@ def penman(DAY, LAT, ELEV, TMIN, TMAX, AVRAD, VAP, WIND2, ANGSTA, ANGSTB):
     GAMMA = PSYCON*PBAR/1013.
 
     # saturated vapour pressure according to equation of Goudriaan
-    # (1977) derivative of SVAP with respect to temperature, i.e. 
+    # (1977) derivative of SVAP with respect to temperature, i.e.
     # slope of the SVAP-temperature curve (mbar/Celsius);
     # measured vapour pressure not to exceed saturated vapour pressure
 
@@ -199,14 +199,14 @@ def penman(DAY, LAT, ELEV, TMIN, TMAX, AVRAD, VAP, WIND2, ANGSTA, ANGSTB):
 
     # Penman formula (1948)
     E0  = (DELTA*RNW+GAMMA*EA)/(DELTA+GAMMA)
-    ES0 = (DELTA*RNS+GAMMA*EA)/(DELTA+GAMMA) 
+    ES0 = (DELTA*RNS+GAMMA*EA)/(DELTA+GAMMA)
     ET0 = (DELTA*RNC+GAMMA*EAC)/(DELTA+GAMMA)
 
     # Ensure reference evaporation >= 0.
     E0  = max(0., E0)
     ES0 = max(0., ES0)
     ET0 = max(0., ET0)
-    
+
     return E0, ES0, ET0
 
 
@@ -309,7 +309,7 @@ def penman_monteith(DAY, LAT, ELEV, TMIN, TMAX, AVRAD, VAP, WIND2):
 
 def check_angstromAB(xA, xB):
     """Routine checks validity of Angstrom coefficients.
-    
+
     This is the  python version of the FORTRAN routine 'WSCAB' in 'weather.for'.
     """
     MIN_A = 0.1
@@ -388,22 +388,22 @@ def vap_from_relhum(rh, temp):
 
 def angstrom(day, latitude, ssd, cA, cB):
     """Compute global radiation using the Angstrom equation.
-    
+
     Global radiation is derived from sunshine duration using the Angstrom
     equation:
     globrad = Angot * (cA + cB * (sunshine / daylength)
-    
+
     :param day: day of observation (date object)
     :param latitude: Latitude of the observation
     :param ssd: Observed sunshine duration
     :param cA: Angstrom A parameter
-    :param cB: Angstrom B parameter    
+    :param cB: Angstrom B parameter
     :returns: the global radiation in J/m2/day
     """
     r = astro(day, latitude, 0)
     globrad = r.ANGOT * (cA + cB * (ssd / r.DAYL))
     return globrad
-                       
+
 
 def doy(day):
     """Converts a date or datetime object to day-of-year (Jan 1st = doy 1)
@@ -422,7 +422,7 @@ def limit(vmin, vmax, v):
 
     if vmin > vmax:
         raise RuntimeError("Min value (%f) larger than max (%f)" % (vmin, vmax))
-    
+
     if v < vmin:       # V below range: return min
         return vmin
     elif v < vmax:     # v within range: return v
@@ -438,7 +438,7 @@ def daylength(day, latitude, angle=-4, _cache={}):
     :param latitude:    latitude of location
     :param angle:       The photoperiodic daylength starts/ends when the sun
         is `angle` degrees under the horizon. Default is -4 degrees.
-    
+
     Derived from the WOFOST routine ASTRO.FOR and simplified to include only
     daylength calculation. Results are being cached for performance
     """
@@ -448,10 +448,10 @@ def daylength(day, latitude, angle=-4, _cache={}):
     if abs(latitude) > 90.:
         msg = "Latitude not between -90 and 90"
         raise RuntimeError(msg)
-    
+
     # Calculate day-of-year from date object day
     IDAY = doy(day)
-    
+
     # Test if daylength for given (day, latitude, angle) was already calculated
     # in a previous run. If not (e.g. KeyError) calculate the daylength, store
     # in cache and return the value.
@@ -459,7 +459,7 @@ def daylength(day, latitude, angle=-4, _cache={}):
         return _cache[(IDAY, latitude, angle)]
     except KeyError:
         pass
-    
+
     # constants
     RAD = radians(1.)
 
@@ -481,13 +481,13 @@ def daylength(day, latitude, angle=-4, _cache={}):
 
     # store results in cache
     _cache[(IDAY, latitude, angle)] = DAYLP
-    
+
     return DAYLP
 
 
 def astro(day, latitude, radiation, _cache={}):
     """python version of ASTRO routine by Daniel van Kraalingen.
-    
+
     This subroutine calculates astronomic daylength, diurnal radiation
     characteristics such as the atmospheric transmission, diffuse radiation etc.
 
@@ -497,19 +497,19 @@ def astro(day, latitude, radiation, _cache={}):
 
     output is a `namedtuple` in the following order and tags::
 
-        DAYL      Astronomical daylength (base = 0 degrees)     h      
-        DAYLP     Astronomical daylength (base =-4 degrees)     h      
-        SINLD     Seasonal offset of sine of solar height       -      
-        COSLD     Amplitude of sine of solar height             -      
+        DAYL      Astronomical daylength (base = 0 degrees)     h
+        DAYLP     Astronomical daylength (base =-4 degrees)     h
+        SINLD     Seasonal offset of sine of solar height       -
+        COSLD     Amplitude of sine of solar height             -
         DIFPP     Diffuse irradiation perpendicular to
-                  direction of light                         J m-2 s-1 
-        ATMTR     Daily atmospheric transmission                -      
+                  direction of light                         J m-2 s-1
+        ATMTR     Daily atmospheric transmission                -
         DSINBE    Daily total of effective solar height         s
         ANGOT     Angot radiation at top of atmosphere       J m-2 d-1
- 
+
     Authors: Daniel van Kraalingen
     Date   : April 1991
- 
+
     Python version
     Author      : Allard de Wit
     Date        : January 2011
@@ -520,10 +520,10 @@ def astro(day, latitude, radiation, _cache={}):
         msg = "Latitude not between -90 and 90"
         raise RuntimeError(msg)
     LAT = latitude
-        
+
     # Determine day-of-year (IDAY) from day
     IDAY = doy(day)
-    
+
     # reassign radiation
     AVRAD = radiation
 
@@ -550,7 +550,7 @@ def astro(day, latitude, radiation, _cache={}):
     AOB = SINLD/COSLD
 
     # For very high latitudes and days in summer and winter a limit is
-    # inserted to avoid math errors when daylength reaches 24 hours in 
+    # inserted to avoid math errors when daylength reaches 24 hours in
     # summer or 0 hours in winter.
 
     # Calculate solution for base=0 degrees
@@ -563,7 +563,7 @@ def astro(day, latitude, radiation, _cache={}):
     else:
         if AOB >  1.0: DAYL = 24.0
         if AOB < -1.0: DAYL = 0.0
-        # integrals of sine of solar height	
+        # integrals of sine of solar height
         DSINB = 3600.*(DAYL*SINLD)
         DSINBE = 3600.*(DAYL*(SINLD+0.4*(SINLD**2+COSLD**2*0.5)))
 
@@ -604,15 +604,15 @@ def astro(day, latitude, radiation, _cache={}):
 
 class Afgen(object):
     """Emulates the AFGEN function in WOFOST.
-    
+
     :param tbl_xy: List or array of XY value pairs describing the function
         the X values should be mononically increasing.
 
-    Returns the interpolated value provided with the 
+    Returns the interpolated value provided with the
     absicca value at which the interpolation should take place.
-    
+
     example::
-    
+
         >>> tbl_xy = [0,0,1,1,5,10]
         >>> f =  Afgen(tbl_xy)
         >>> f(0.5)
@@ -626,21 +626,21 @@ class Afgen(object):
         >>> f(-1)
         0.0
     """
-    
+
     def _check_x_ascending(self, tbl_xy):
         """Checks that the x values are strictly ascending.
-        
+
         Also truncates any trailing (0.,0.) pairs as a results of data coming
         from a CGMS database.
         """
         x_list = tbl_xy[0::2]
         y_list = tbl_xy[1::2]
         n = len(x_list)
-        
+
         # Check if x range is ascending continuously
         rng = list(range(1, n))
         x_asc = [True if (x_list[i] > x_list[i-1]) else False for i in rng]
-        
+
         # Check for breaks in the series where the ascending sequence stops.
         # Only 0 or 1 breaks are allowed. Use the XOR operator '^' here
         sum_break = sum([1 if (x0 ^ x1) else 0 for x0,x1 in zip(x_asc, x_asc[1:])])
@@ -658,11 +658,11 @@ class Afgen(object):
             msg = ("X values for AFGEN input list not strictly ascending: %s"
                    % x_list)
             raise ValueError(msg)
-        
-        return x, y            
+
+        return x, y
 
     def __init__(self, tbl_xy):
-        
+
         x_list, y_list = self._check_x_ascending(tbl_xy)
         x_list = self.x_list = list(map(float, x_list))
         y_list = self.y_list = list(map(float, y_list))
@@ -697,15 +697,15 @@ class AfgenTrait(TraitType):
 
 def merge_dict(d1, d2, overwrite=False):
     """Merge contents of d1 and d2 and return the merged dictionary
-    
+
     Note:
-    
+
     * The dictionaries d1 and d2 are unaltered.
     * If `overwrite=False` (default), a `RuntimeError` will be raised when
       duplicate keys exist, else any existing keys in d1 are silently
-      overwritten by d2.  
+      overwritten by d2.
     """
-    # Note: May  partially be replaced by a ChainMap as of python 3.3 
+    # Note: May  partially be replaced by a ChainMap as of python 3.3
     if overwrite is False:
         sd1 = set(d1.keys())
         sd2 = set(d2.keys())
@@ -926,6 +926,13 @@ class DummySoilDataProvider(dict):
         dict.__init__(self)
         self.update(self._defaults)
 
+    def copy(self):
+        """
+        Overrides the inherited dict.copy method, which returns a dict.
+        This instead preserves the class and attributes like .header.
+        """
+        return copy.copy(self)
+
 
 def version_tuple(v):
     """Creates a version tuple from a version string for consistent comparison of versions.
@@ -1003,7 +1010,7 @@ class WOFOST72SiteDataProvider(_GenericSiteDataProvider):
 
     Currently only the value for WAV is mandatory to specify.
     """
-    
+
     _defaults = {"IFUNRN": (0, {0, 1}, int),
                  "NOTINF": (0, [0., 1.], float),
                  "SSI": (0., [0., 100.], float),


### PR DESCRIPTION
### Description
`CABOFileReader`, `PCSEFileReader`, and `DummySoilDataProvider` are subclassed from `dict` and therefore inherit its `dict.copy` method. This causes an issue when the user tries to use this method to copy an instance of these objects, because `dict.copy` always returns a `dict` object, not the subclass.

The fix has been implemented for these three classes because they are user-facing (by which I mean I have used them). There are other subclasses of `dict`, like `MultiCropDataProvider`, where I'm not sure if it's necessary; and others, like the various CGMS DataProviders, which I have not used at all and thus don't want to blindly edit. A more general fix might be to switch from subclassing `dict` to subclassing `collections.UserDict`, but this is not trivial. Additionally, a similar issue exists for classes that subclass `list` or `set`, such as `YAMLAgroManagementReader`, but again I am not sure if these are commonly copied by users and/or I don't have experience working with these classes. However, it should be very straight-forward to apply the same fix elsewhere. Finally, other classes do not come with an inherited-but-broken `.copy` method and thus do not require any changes.

### Example
A parameter file 'parfile.cab' which looks like this:
```
** CROP DATA FILE for use with WOFOST Version 5.4, June 1992
**
** WHEAT, WINTER 102
** Regions: Ireland, central and southern UK (R72-R79),
**          Netherlands (not R47), northern Germany (R11-R14)
CRPNAM='Winter wheat 102, Ireland, N-U.K., Netherlands, N-Germany'
CROP_NO=99
TBASEM   = -10.0    ! lower threshold temp. for emergence [cel]
DTSMTB   =   0.00,    0.00,     ! daily increase in temp. sum
            30.00,   30.00,     ! as function of av. temp. [cel; cel d]
            45.00,   30.00
** maximum and minimum concentrations of N, P, and K
** in storage organs        in vegetative organs [kg kg-1]
NMINSO   =   0.0110 ;       NMINVE   =   0.0030
```
Can be read as follows:
```python
>>> from pcse.fileinput import CABOFileReader
>>> cabo = CABOFileReader("parfile.cab")

>>> print(cabo)
** CROP DATA FILE for use with WOFOST Version 5.4, June 1992
**
** WHEAT, WINTER 102
** Regions: Ireland, central and southern UK (R72-R79),
**          Netherlands (not R47), northern Germany (R11-R14)
------------------------------------
CROP_NO: 99 <class 'int'>
TBASEM: -10.0 <class 'float'>
NMINSO: 0.011 <class 'float'>
NMINVE: 0.003 <class 'float'>
CRPNAM: Winter wheat 102, Ireland, N-U.K., Netherlands, N-Germany <class 'str'>
DTSMTB: [0.0, 0.0, 30.0, 30.0, 45.0, 30.0] <class 'list'>

>>> type(cabo)
pcse.fileinput.cabo_reader.CABOFileReader
```

### Current behaviour
The resulting `cabo` instance has a `.copy` method inherited from `dict`, which a user may encounter and try to use (I certainly did). However, this leads to unexpected and unwanted behaviour:
```python
>>> cabo_copy = cabo.copy()
>>> print(cabo_copy)
{'CROP_NO': 99, 'TBASEM': -10.0, 'NMINSO': 0.011, 'NMINVE': 0.003, 'CRPNAM': 'Winter wheat 102, Ireland, N-U.K., Netherlands, N-Germany', 'DTSMTB': [0.0, 0.0, 30.0, 30.0, 45.0, 30.0]}

>>> type(cabo_copy)
dict

>>> print(cabo_copy.header)
Traceback (most recent call last):

  Cell In[8], line 1
    print(cabo_copy.header)

AttributeError: 'dict' object has no attribute 'header'
```

### Solution
A `.copy` method has been added which uses the Python standard library `copy.copy` shallow-copying functionality. This makes `cabo.copy()` equivalent to `copy.copy(cabo)`, which works properly out of the box.

```python
>>> cabo_copy = cabo.copy()
>>> print(cabo_copy)
** CROP DATA FILE for use with WOFOST Version 5.4, June 1992
**
** WHEAT, WINTER 102
** Regions: Ireland, central and southern UK (R72-R79),
**          Netherlands (not R47), northern Germany (R11-R14)
------------------------------------
CROP_NO: 99 <class 'int'>
TBASEM: -10.0 <class 'float'>
NMINSO: 0.011 <class 'float'>
NMINVE: 0.003 <class 'float'>
CRPNAM: Winter wheat 102, Ireland, N-U.K., Netherlands, N-Germany <class 'str'>
DTSMTB: [0.0, 0.0, 30.0, 30.0, 45.0, 30.0] <class 'list'>

>>> type(cabo_copy)
pcse.fileinput.cabo_reader.CABOFileReader

>>> cabo_copy == cabo
True

>>> cabo_copy is cabo
False
```

