### PR TITLE
fix soil wrapper import

### DIFF
--- a/pcse/conf/Lingra_NWLP_FD.conf
+++ b/pcse/conf/Lingra_NWLP_FD.conf
@@ -7,10 +7,10 @@ production using the free drainage waterbalance.
 
 from pcse.crop.lingraN import LINGRA_N
 from pcse.agromanager import AgroManager
-from pcse.soil.soil_wrappers import SoilModuleWrapper_N_WLP_FD
+from pcse.soil.soil_wrappers import SoilModuleWrapper_NWLP_CWB_CNB
 
 # Module to be used for water balance
-SOIL = SoilModuleWrapper_N_WLP_FD
+SOIL = SoilModuleWrapper_NWLP_CWB_CNB
 
 # Module to be used for the crop simulation itself
 CROP = LINGRA_N


### PR DESCRIPTION
This pull request updates the configuration file `Lingra_NWLP_FD.conf` to use a different soil module for water balance calculations in the crop simulation. The change ensures compatibility with the new soil module.

Key change:

* Updated the soil module from `SoilModuleWrapper_N_WLP_FD` to `SoilModuleWrapper_NWLP_CWB_CNB` in `pcse/conf/Lingra_NWLP_FD.conf` to align with the updated water balance requirements.

Closes #104 
