### PR TITLE
Incorporation of crop residues added to SNOMIN + CropCalendar

### DIFF
--- a/pcse/agromanager.py
+++ b/pcse/agromanager.py
@@ -103,7 +103,8 @@ class CropCalendar(HasTraits, DispatcherObject):
     in_crop_cycle = Bool(False)
 
     def __init__(self, kiosk, crop_name=None, variety_name=None, crop_start_date=None,
-                 crop_start_type=None, crop_end_date=None, crop_end_type=None, max_duration=None):
+                 crop_start_type=None, crop_end_date=None, crop_end_type=None, max_duration=None ,
+                 frac_LV_har = None, frac_ST_har = None, frac_SO_har = None, ploughing_depth = None):
 
         # set up logging
         loggername = "%s.%s" % (self.__class__.__module__,
@@ -118,6 +119,11 @@ class CropCalendar(HasTraits, DispatcherObject):
         self.crop_end_date = crop_end_date
         self.crop_end_type = crop_end_type
         self.max_duration = max_duration
+
+        self.frac_LV_har = frac_LV_har
+        self.frac_ST_har = frac_ST_har
+        self.frac_SO_har = frac_SO_har
+        self.ploughing_depth = ploughing_depth
 
         self._connect_signal(self._on_CROP_FINISH, signal=signals.crop_finish)
 
@@ -177,11 +183,58 @@ class CropCalendar(HasTraits, DispatcherObject):
             if self.in_crop_cycle and self.duration == self.max_duration:
                 finish_type = "max_duration"
 
+        # Check if any crop residues are left on the field
+        if all([self.frac_LV_har is None,
+                self.frac_ST_har is None,
+                self.frac_SO_har is None,
+                self.ploughing_depth is None]):
+            # If the ploughing depth and the fractions of leaves, stems, and storage organs are not defined, assume
+            # that all crop residues are harvested.
+            self.frac_LV_har = 1.0,
+            self.frac_ST_har = 1.0,
+            self.frac_SO_har = 1.0,
+            self.ploughing_depth = 0
+        elif all([self.frac_LV_har is not None,
+                  self.frac_ST_har is not None,
+                  self.frac_SO_har is not None,
+                  self.ploughing_depth is not None]):
+            # If the ploughing depth and the fractions of leaves, stems, and storage organs are not defined, assume
+            # that a fraction of the crop residues remain of the field
+            pass
+        else:
+            msg_missing_fraction = ("Warning, {var_name} is not defined. It is assumed that the {organ_name} are fully "
+                                    "harvested.")
+            if self.frac_LV_har is None:
+                self.frac_LV_har = 1.0
+                organ_name = "leaves"
+                msg = msg_missing_fraction.format(var_name="frac_LV_har", organ_name=organ_name)
+                print(msg)
+            if self.frac_ST_har is None:
+                self.frac_ST_har = 1.0
+                organ_name = "stems"
+                msg = msg_missing_fraction.format(var_name="frac_ST_har", organ_name=organ_name)
+                print(msg)
+            if self.frac_SO_har is None:
+                self.frac_SO_har = 1.0
+                organ_name = "storage organs"
+                msg = msg_missing_fraction.format(var_name="frac_ST_har", organ_name=organ_name)
+                print(msg)
+            if self.ploughing_depth is None:
+                self.ploughing_depth = 0.0
+                msg_missing_ploughing_depth = (
+                    "Warning, ploughing depth is not defined. It is assumed that all crop residues "
+                    "are incorporated in the top soil layer.")
+                print(msg_missing_ploughing_depth)
+
         # If finish condition is reached send a signal to finish the crop
         if finish_type is not None:
             self.in_crop_cycle = False
             self._send_signal(signal=signals.crop_finish, day=day,
-                              finish_type=finish_type, crop_delete=True)
+                              finish_type=finish_type, crop_delete=True,
+                              frac_LV_har=self.frac_LV_har, frac_ST_har=self.frac_ST_har,
+                              frac_SO_har=self.frac_SO_har, ploughing_depth=self.ploughing_depth)
+
+
 
     def _on_CROP_FINISH(self):
         """Register that crop has reached the end of its cycle.

--- a/pcse/agromanager.py
+++ b/pcse/agromanager.py
@@ -234,8 +234,6 @@ class CropCalendar(HasTraits, DispatcherObject):
                               frac_LV_har=self.frac_LV_har, frac_ST_har=self.frac_ST_har,
                               frac_SO_har=self.frac_SO_har, ploughing_depth=self.ploughing_depth)
 
-
-
     def _on_CROP_FINISH(self):
         """Register that crop has reached the end of its cycle.
         """

--- a/pcse/soil/snomin.py
+++ b/pcse/soil/snomin.py
@@ -11,7 +11,6 @@ from pcse import signals
 from ..traitlets import Float, Int, Instance, Bool
 # from .soiln_profile import SoilNProfile
 
-
 class SNOMIN(SimulationObject):
     """
     SNOMIN (Soil Nitrogen module for Mineral and Inorganic Nitrogen) is a layered soil nitrogen balance. A
@@ -333,6 +332,7 @@ class SNOMIN(SimulationObject):
 
         # Connect module to signal AgroManager
         self._connect_signal(self._on_APPLY_N_SNOMIN, signals.apply_n_snomin)
+        self._connect_signal(self._ON_HARVEST_SNOMIN, signals.crop_finish)
 
     @prepare_rates
     def calc_rates(self, day, drv):
@@ -483,7 +483,7 @@ class SNOMIN(SimulationObject):
         s.NLOSSCUM = NLOSSCUM
 
     def _on_APPLY_N_SNOMIN(self, amount=None, application_depth = None, cnratio=None, f_orgmat=None,
-                           f_NH4N = None, f_NO3N = None, initial_age =None):
+                           f_NH4N = None, f_NO3N = None, initial_age = None):
         """This function calculates the application rates of organic matter, organic C, organic N, NH4-N, NO3-N
         and the initial apparent age of the applied material at the date of application.
 
@@ -547,6 +547,33 @@ class SNOMIN(SimulationObject):
         self._RNORGAM = np.concatenate(( self._RNORGAM, RNORG_am), axis = 0)
         self._RNH4AM = RNH4_am
         self._RNO3AM = RNO3_am
+
+    def _ON_HARVEST_SNOMIN(self, frac_LV_har = None, frac_ST_har = None, frac_SO_har = None, ploughing_depth = None):
+        k = self.kiosk
+        WLV_residue = (1 - frac_LV_har) * k.WLV
+        WSO_residue = (1 - frac_SO_har) * k.WSO
+        WST_residue = (1 - frac_ST_har) * k.WST
+        NamountLV_residue = (1 - frac_LV_har) * k.NamountLV
+        NamountST_residue = (1 - frac_ST_har) * k.NamountST
+        NamountSO_residue = (1 - frac_SO_har) * k.NamountSO
+
+        W_residue = WLV_residue + WSO_residue + WST_residue
+        frac_C = self.SoilOrganicNModel.MINIP_C.OM_to_C
+        C_residue = W_residue * frac_C
+        Namount_residue = NamountLV_residue + NamountST_residue + NamountSO_residue
+
+        if Namount_residue == 0:
+            CN_ratio = 1e9
+        else:
+            CN_ratio = C_residue / Namount_residue
+
+        self._on_APPLY_N_SNOMIN(amount=W_residue,
+                                application_depth = ploughing_depth,
+                                cnratio=CN_ratio,
+                                f_orgmat=1.0,
+                                f_NH4N = 0.,
+                                f_NO3N = 0.,
+                                initial_age = 3.16)
 
     def get_infiltration_rate(self, k):
         infiltration_rate_m_per_d = k.RIN * self.cm_to_m

--- a/pcse/soil/snomin.py
+++ b/pcse/soil/snomin.py
@@ -515,11 +515,6 @@ class SNOMIN(SimulationObject):
         # Initialize amendment rates
         RAGE_am = np.zeros((1, len(self.soiln_profile)))
         AGE0_am = np.zeros_like(RAGE_am)
-        RORGMAT_am = np.zeros_like(RAGE_am)
-        RCORG_am = np.zeros_like(RAGE_am)
-        RNORG_am = np.zeros_like(RAGE_am)
-        RNH4_am = np.zeros_like(s.NH4)
-        RNO3_am = np.zeros_like(s.NO3)
 
         # Prevents that a part of the N is not applied if the application depth is less than thickness of the upper layer
         if application_depth < self.soiln_profile[0].Thickness:
@@ -560,12 +555,8 @@ class SNOMIN(SimulationObject):
         W_residue_shoot = WLV_residue + WSO_residue + WST_residue
         frac_C = self.SoilOrganicNModel.MINIP_C.OM_to_C
         C_residue_shoot  = W_residue_shoot  * frac_C
-        Namount_residue_shoot  = NamountLV_residue + NamountST_residue + NamountSO_residue
-
-        if Namount_residue_shoot == 0:
-            CN_ratio_shoot = 1e9
-        else:
-            CN_ratio_shoot = C_residue_shoot / Namount_residue_shoot
+        Namount_residue_shoot  = max(0.001, NamountLV_residue + NamountST_residue + NamountSO_residue)
+        CN_ratio_shoot = C_residue_shoot / Namount_residue_shoot
 
         self._on_APPLY_N_SNOMIN(amount=W_residue_shoot ,
                                 application_depth = ploughing_depth,
@@ -577,12 +568,8 @@ class SNOMIN(SimulationObject):
 
         W_residue_root = k.WRT
         C_residue_root = W_residue_root * frac_C
-        Namount_residue_root = k.NamountRT
-
-        if Namount_residue_shoot == 0:
-            CN_ratio_root = 1e9
-        else:
-            CN_ratio_root = C_residue_root / Namount_residue_root
+        Namount_residue_root = max(0.001, k.NamountRT)
+        CN_ratio_root = C_residue_root / Namount_residue_root
 
         self._on_APPLY_N_SNOMIN(amount=W_residue_shoot ,
                                 application_depth = k.RD,

--- a/pcse/soil/snomin.py
+++ b/pcse/soil/snomin.py
@@ -557,23 +557,40 @@ class SNOMIN(SimulationObject):
         NamountST_residue = (1 - frac_ST_har) * k.NamountST
         NamountSO_residue = (1 - frac_SO_har) * k.NamountSO
 
-        W_residue = WLV_residue + WSO_residue + WST_residue
+        W_residue_shoot = WLV_residue + WSO_residue + WST_residue
         frac_C = self.SoilOrganicNModel.MINIP_C.OM_to_C
-        C_residue = W_residue * frac_C
-        Namount_residue = NamountLV_residue + NamountST_residue + NamountSO_residue
+        C_residue_shoot  = W_residue_shoot  * frac_C
+        Namount_residue_shoot  = NamountLV_residue + NamountST_residue + NamountSO_residue
 
-        if Namount_residue == 0:
-            CN_ratio = 1e9
+        if Namount_residue_shoot == 0:
+            CN_ratio_shoot = 1e9
         else:
-            CN_ratio = C_residue / Namount_residue
+            CN_ratio_shoot = C_residue_shoot / Namount_residue_shoot
 
-        self._on_APPLY_N_SNOMIN(amount=W_residue,
+        self._on_APPLY_N_SNOMIN(amount=W_residue_shoot ,
                                 application_depth = ploughing_depth,
-                                cnratio=CN_ratio,
+                                cnratio=CN_ratio_shoot,
                                 f_orgmat=1.0,
                                 f_NH4N = 0.,
                                 f_NO3N = 0.,
-                                initial_age = 3.16)
+                                initial_age = 0.99)
+
+        W_residue_root = k.WRT
+        C_residue_root = W_residue_root * frac_C
+        Namount_residue_root = k.NamountRT
+
+        if Namount_residue_shoot == 0:
+            CN_ratio_root = 1e9
+        else:
+            CN_ratio_root = C_residue_root / Namount_residue_root
+
+        self._on_APPLY_N_SNOMIN(amount=W_residue_shoot ,
+                                application_depth = k.RD,
+                                cnratio=CN_ratio_root,
+                                f_orgmat=1.0,
+                                f_NH4N = 0.,
+                                f_NO3N = 0.,
+                                initial_age = 1.57)
 
     def get_infiltration_rate(self, k):
         infiltration_rate_m_per_d = k.RIN * self.cm_to_m


### PR DESCRIPTION
Dear Allard,

I have functionality to SNOMIN to enable the incorporation of crop residues at the harvest date. This change required also some changes in CropCalendar in agromanager.py. To prevent that these changes break the existing functionality to read AgroManagement dictionaries, I have made all arguments for incorporation of crop residues optimal. If they are not given, it is assumed that all crop residues are harvested (as was implicitly assumed by the original version of SNOMIN).

Best regards,

Herman