### PR TITLE
Fix iterator method for the ParameterProvider

### DIFF
--- a/pcse/base/parameter_providers.py
+++ b/pcse/base/parameter_providers.py
@@ -254,7 +254,7 @@ class ParameterProvider(MutableMapping):
         return len(self._unique_parameters)
 
     def __iter__(self):
-        return self
+        return iter(self._unique_parameters)
 
     def next(self):
         i = self._iter


### PR DESCRIPTION
I am suggesting a fix for the `__iter__` method for the ParameterProvider, so that one can use built-in dict-like methods such as `.items()`, `.keys()` and `.values()` on these objects.