### PR TITLE
Correction in calculation N amounts in residues

### DIFF
--- a/pcse/soil/snomin.py
+++ b/pcse/soil/snomin.py
@@ -585,9 +585,9 @@ class SNOMIN(SimulationObject):
         WLV_residue = (1 - self._frac_LV_harvested) * k.WLV
         WSO_residue = (1 - self._frac_SO_harvested) * k.WSO
         WST_residue = (1 - self._frac_ST_harvested) * k.WST
-        NamountLV_residue = WLV_residue * k.NamountLV
-        NamountST_residue = WST_residue * k.NamountST
-        NamountSO_residue = WSO_residue * k.NamountSO
+        NamountLV_residue = k.NamountLV
+        NamountST_residue = k.NamountST
+        NamountSO_residue = k.NamountSO
 
         W_residue_shoot = WLV_residue + WSO_residue + WST_residue
         frac_C = self.SoilOrganicNModel.MINIP_C.OM_to_C


### PR DESCRIPTION
The N amounts in the residue of a particular aboveground organ was calculated as the product of the dry weight and the N amount in this organ. This was not correct as the N amount in the residue of an organ should have been equal to the amount of N in the organ at harvest instead.