### PR TITLE
Suggestion Nadia added to multiply the amount of N in residue with the fraction that is not harvested.

### DIFF
--- a/pcse/soil/snomin.py
+++ b/pcse/soil/snomin.py
@@ -585,9 +585,9 @@ class SNOMIN(SimulationObject):
         WLV_residue = (1 - self._frac_LV_harvested) * k.WLV
         WSO_residue = (1 - self._frac_SO_harvested) * k.WSO
         WST_residue = (1 - self._frac_ST_harvested) * k.WST
-        NamountLV_residue = k.NamountLV
-        NamountST_residue = k.NamountST
-        NamountSO_residue = k.NamountSO
+        NamountLV_residue = k.NamountLV * (1 - self._frac_LV_harvested)
+        NamountST_residue = k.NamountST * (1 - self._frac_ST_harvested)
+        NamountSO_residue = k.NamountSO * (1 - self._frac_SO_harvested)
 
         W_residue_shoot = WLV_residue + WSO_residue + WST_residue
         frac_C = self.SoilOrganicNModel.MINIP_C.OM_to_C

--- a/pcse/soil/snomin.py
+++ b/pcse/soil/snomin.py
@@ -585,9 +585,9 @@ class SNOMIN(SimulationObject):
         WLV_residue = (1 - self._frac_LV_harvested) * k.WLV
         WSO_residue = (1 - self._frac_SO_harvested) * k.WSO
         WST_residue = (1 - self._frac_ST_harvested) * k.WST
-        NamountLV_residue = k.NamountLV * (1 - self._frac_LV_harvested)
-        NamountST_residue = k.NamountST * (1 - self._frac_ST_harvested)
-        NamountSO_residue = k.NamountSO * (1 - self._frac_SO_harvested)
+        NamountLV_residue = (1 - self._frac_LV_harvested) * k.NamountLV
+        NamountST_residue = (1 - self._frac_ST_harvested) * k.NamountST
+        NamountSO_residue = (1 - self._frac_ST_harvested) * k.NamountSO
 
         W_residue_shoot = WLV_residue + WSO_residue + WST_residue
         frac_C = self.SoilOrganicNModel.MINIP_C.OM_to_C

--- a/pcse/soil/snomin.py
+++ b/pcse/soil/snomin.py
@@ -587,7 +587,7 @@ class SNOMIN(SimulationObject):
         WST_residue = (1 - self._frac_ST_harvested) * k.WST
         NamountLV_residue = (1 - self._frac_LV_harvested) * k.NamountLV
         NamountST_residue = (1 - self._frac_ST_harvested) * k.NamountST
-        NamountSO_residue = (1 - self._frac_ST_harvested) * k.NamountSO
+        NamountSO_residue = (1 - self._frac_SO_harvested) * k.NamountSO
 
         W_residue_shoot = WLV_residue + WSO_residue + WST_residue
         frac_C = self.SoilOrganicNModel.MINIP_C.OM_to_C


### PR DESCRIPTION
The amount of N in the stems, leaves, and storage organs was set equal to the amounts of N in the organs. However, only a fraction of this N is incorporated for each organ as the remaining fraction is harvested. Therefore, the amounts of N in the shoot organ residues should equal the amounts of N in these organs multiplied with the fraction of that organ that is not harvested.